### PR TITLE
Center tile background pictures

### DIFF
--- a/src/site/_includes/css/tiles.css
+++ b/src/site/_includes/css/tiles.css
@@ -4,6 +4,7 @@
   /* background image in element style. include linear-gradient(black, black) for grayscale */
   background-size: cover;
   background-blend-mode: saturation;
+  background-position: center;
 }
 
 /* https://stackoverflow.com/questions/29307971/css-grid-of-squares-with-flexbox */


### PR DESCRIPTION
This PR will fix that images from participants are showing cut-off faces/hair.

Before:
<img width="774" alt="Bildschirmfoto 2022-08-12 um 02 26 39" src="https://user-images.githubusercontent.com/61689369/184264032-836ad7d2-f914-4ccd-8c1f-e4fdde5e7658.png">


After:
<img width="774" alt="Bildschirmfoto 2022-08-12 um 02 27 02" src="https://user-images.githubusercontent.com/61689369/184264063-d3180d0f-7a94-4f56-921b-3dd8383de353.png">

