### PR TITLE
Fix 501©(3) → 501(c)(3) typo + bump copyright years to 2026

### DIFF
--- a/src/site/_includes/components/conference-menu.njk
+++ b/src/site/_includes/components/conference-menu.njk
@@ -64,7 +64,7 @@
         </ul>
       </div>
       <p class="hidden lg:block py-2 text-size--4 text-center">
-        © 2021 RadicalxChange Foundation Ltd.
+        © 2026 RadicalxChange Foundation Ltd.
       </p>
     </nav>
     <div

--- a/src/site/_includes/components/footer.njk
+++ b/src/site/_includes/components/footer.njk
@@ -216,7 +216,7 @@
         />
       </div>
       <p class="text-center text-size--4">
-        © 2021 RadicalxChange Foundation Ltd.
+        © 2026 RadicalxChange Foundation Ltd.
       </p>
       <p class="text-center text-size--4">
         RadicalxChange Foundation Ltd., a 501(c)(3) nonprofit organization, does

--- a/src/site/_includes/components/menu.njk
+++ b/src/site/_includes/components/menu.njk
@@ -96,7 +96,7 @@
         </ul>
       </div>
       <p class="hidden lg:block py-2 text-size--4 text-center">
-        © 2025 RadicalxChange Foundation Ltd.
+        © 2026 RadicalxChange Foundation Ltd.
       </p>
     </nav>
     <div

--- a/src/site/_includes/components/project-page.njk
+++ b/src/site/_includes/components/project-page.njk
@@ -123,7 +123,7 @@
   {% endfor %}
   <div class="col-span-columns hidden lg:block mt-16">
     <p class="text-center text-size--4">
-      © 2020 RadicalxChange Foundation Ltd.
+      © 2026 RadicalxChange Foundation Ltd.
     </p>
     <p class="text-center text-size--4">
       RadicalxChange Foundation Ltd., a 501(c)(3) nonprofit organization, does

--- a/src/site/events/2024-plurality-european-tour/index.njk
+++ b/src/site/events/2024-plurality-european-tour/index.njk
@@ -187,7 +187,7 @@ aboutAudreyBody: |
 aboutGlenBody: |
   Glen Weyl is a co-founder and the Chair of Plurality Institute, the Research Lead of Microsoft Research's Plural Technology Collaboratory,  Founder of RadicalxChange Foundation, and co-author of Radical Markets and *⿻ 數位 Plurality: The Future of Collaborative Technology and Democracy*. He was Valedictorian of Princeton University in 2007, received his PhD in economics from the same in 2008, was a Junior Fellow of the Harvard Society of Fellows, an Alfred P. Sloan Fellow and has taught economics at University of Chicago, Princeton, Harvard and Yale.
 rxcBlurb: |
-  RadicalxChange Foundation is a 501©(3) nonprofit organization dedicated to democratic innovation and institutional design through operational partnerships and experimental projects between academia, government, art, technology, and beyond.
+  RadicalxChange Foundation is a 501(c)(3) nonprofit organization dedicated to democratic innovation and institutional design through operational partnerships and experimental projects between academia, government, art, technology, and beyond.
 ---
 
 <!-- prettier-ignore -->


### PR DESCRIPTION
Five small edits in one commit, no functional or content changes beyond the literal substitutions.

## The 501(c)(3) fix

`501©(3)` (the autocorrect-introduced copyright symbol) → `501(c)(3)` (the literal three-character `(c)`):

- [src/site/events/2024-plurality-european-tour/index.njk:190](https://github.com/RadicalxChange/www/blob/fix-501c3-typo/src/site/events/2024-plurality-european-tour/index.njk#L190)

Repo-wide search confirmed only one occurrence.

## Copyright year bumps

Four `© YYYY RadicalxChange Foundation Ltd.` footer lines bumped to `© 2026`:

- [src/site/_includes/components/menu.njk:99](https://github.com/RadicalxChange/www/blob/fix-501c3-typo/src/site/_includes/components/menu.njk#L99) — 2025 → 2026
- [src/site/_includes/components/project-page.njk:126](https://github.com/RadicalxChange/www/blob/fix-501c3-typo/src/site/_includes/components/project-page.njk#L126) — 2020 → 2026
- [src/site/_includes/components/footer.njk:219](https://github.com/RadicalxChange/www/blob/fix-501c3-typo/src/site/_includes/components/footer.njk#L219) — 2021 → 2026
- [src/site/_includes/components/conference-menu.njk:67](https://github.com/RadicalxChange/www/blob/fix-501c3-typo/src/site/_includes/components/conference-menu.njk#L67) — 2021 → 2026

The other `©` occurrences in the repo are these four footers and the one typo — nothing else used `©` in a way that needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)