### PR TITLE
Render 501(c)(3) literally — disable markdown-it text-symbol replacements

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -29,6 +29,11 @@ module.exports = function (config) {
     linkify: true,
     typographer: true,
   })
+    // The `replacements` core rule converts (c)->©, (r)->®, (tm)->™, (p)->§,
+    // ...->…, --->—, --->–, +-->±. Disable it so phrases like "501(c)(3)" and
+    // list items like "(a) ... (b) ... (c) ..." render literally. Smart quotes
+    // remain on (handled by the separate `smartquotes` rule).
+    .disable("replacements")
     .use(require("markdown-it-anchor"), {
       slugify: uslug,
     })


### PR DESCRIPTION
Follow-up to [#219](https://github.com/RadicalxChange/www/pull/219). That PR fixed five literal-character typos at the source level. This one fixes the build-config root cause that was rewriting correctly-spelled `501(c)(3)` to `501©(3)` on render.

## What's changing

One config-line addition in [.eleventy.js](.eleventy.js):

```js
let markdown = markdownIt({ html: true, linkify: true, typographer: true })
  .disable("replacements")  // <- new
  .use(...)
```

`typographer: true` actually enables two markdown-it core rules: `replacements` (text-symbol shortcuts) and `smartquotes` (curly quotes). We want the latter, not the former. `.disable("replacements")` keeps smartquotes intact.

## Why

`markdown-it` typographer's `replacements` rule was rewriting:

| Source | Renders as |
|---|---|
| `(c)` | © |
| `(r)` | ® |
| `(tm)` | ™ |
| `(p)` | § |
| `...` | … |
| `--` | – |
| `---` | — |
| `+-` | ± |

That meant `501(c)(3)` in markdown frontmatter was rendering as `501©(3)` on every page that uses an `rxcBlurb`-style field, even when the source was correct.

Confirmed previously broken on:
- [src/site/communityweeknyc/index.njk:31](src/site/communityweeknyc/index.njk:31) (`rxcBlurb`)
- [src/site/events/2024-oakland/index.njk:11](src/site/events/2024-oakland/index.njk:11)
- [src/site/events/2024-plurality-european-tour/index.njk:190](src/site/events/2024-plurality-european-tour/index.njk:190)
- [src/site/events/2025-berlin/index.njk:46](src/site/events/2025-berlin/index.njk:46)
- [src/site/events/2025-maine/index.njk:87](src/site/events/2025-maine/index.njk:87)
- [src/site/wiki/about.md:21](src/site/wiki/about.md:21)
- [src/site/updates/blog/2024-11-14_new-solidarity-for-an-ai-disrupted-economy.md:25](src/site/updates/blog/2024-11-14_new-solidarity-for-an-ai-disrupted-economy.md:25) — list reading "(a) license data...(b) in exchange...(c) serve as necessary counterparties" had the (c) item silently turned into ©

## Trade-off

Long-form content authors no longer get auto-conversion of:
- `...` → … (ellipsis)
- `--` → – (en-dash)
- `---` → — (em-dash)
- `+-` → ± (plus-minus)

Smart quotes (`"foo"` → `“foo”`, `'foo'` → `‘foo’`) are unaffected — they're a separate rule.

If a piece of content was relying on `--` to render as an en-dash, it'll now render as two literal hyphens. Easy enough to type the actual character (— is `Opt-Shift--` on macOS). Not ideal for legacy posts but the alternative — leaving `(c)` → © on — keeps the blocking issue we just observed.

## Verified

- ✓ Built site post-change: `501(c)(3)` renders literally on all six affected pages
- ✓ Blog post `(a)/(b)/(c) serve as necessary counterparties` list renders literally
- ✓ Zero `501©` left anywhere in `dist/`
- ✓ Smart quotes still active — sample: `“The Future of Social Connection”` renders with curly U+201C/U+201D

🤖 Generated with [Claude Code](https://claude.com/claude-code)