### PR TITLE
Add Plural Events May 2026 hosting call announcement

### DIFF
--- a/src/site/updates/announcements/2026-04-29_host-a-plural-event-may-2026.md
+++ b/src/site/updates/announcements/2026-04-29_host-a-plural-event-may-2026.md
@@ -1,0 +1,41 @@
+---
+layout: "layouts/announcement.njk"
+date: "2026-04-29"
+slug: "2026-04-host-a-plural-event"
+title: "Host a Plural Event: A Global Conversation on Deliberative Democracy"
+postHeader: "Host a Plural Event: A Global Conversation on Deliberative Democracy"
+---
+
+On **May 14–15**, RadicalxChange communities around the world will gather — in hubs, libraries, universities, and on terraces — to discuss the same question on the same day. We're inviting RxC chapter leads, meetup organizers, and discussion hosts to run a local edition.
+
+## What is a Plural Event?
+
+Now in its third iteration, the Plural Events format is built on a simple premise: when the same topic is discussed in parallel across very different settings, the contrasts and unexpected alignments become as valuable as any individual conversation. Participating communities share facilitation prompts and deliberative tools, and insights from across the global movement will be presented at the [Neocypherpunk Summit by Web3Privacy Now](https://luma.com/f47k4xnd?tk=4M4xU5) in Berlin on June 14, which RxC members are invited to attend.
+
+## The topic: Deliberative Democracy in Practice — Privacy, Coordination, and Collective Action
+
+Deliberative democracy is about creating spaces where people can thoughtfully shape collective decisions. Rather than discussing it in the abstract, this round of Plural Events asks practical questions: What conditions help you feel safe and confident contributing to decisions in your community? What does privacy need to look like for people to share ideas openly — and where does too much restriction undermine transparency? What tools or infrastructure would help your community coordinate and decide together more meaningfully?
+
+## What you might explore at your event
+
+- Identify one local issue where coordination or democratic processes are failing.
+- Propose a tool, action, or process that could improve it.
+- Map where privacy and transparency matter in that context.
+- Create a sketch or prototype.
+- Design a micro collective action — something at least three people could carry out within a week.
+
+## Bounty prizes from Logos
+
+If your event produces an action, prototype, or proposal, you can submit it for review. An independent jury will award **€600, €300, and €100** to the top three ideas, generously funded by [Logos](https://logos.co/). Bonus points if your group actually carries out the action and shares proof within a week. Full contest rules and judging criteria coming soon.
+
+## Who's already on board
+
+Events are confirmed in Barcelona, Berlin, Porto, Rio de Janeiro, Rome, Vienna, Singapore, Brussels, São Paulo, Vancouver, Lisbon, Buenos Aires, Tbilisi, Budapest, Thika, and several cities across Nigeria — with more being added daily. The full list and signup links are at [luma.com/PluralEvents](https://luma.com/PluralEvents).
+
+## Want to host one?
+
+The organizing team is running an info session on **Thursday April 30, 4pm CET** — [sign up here](https://luma.com/r0ccbk9u?tk=QWEaB7). You can also join the conversation directly on the [Plural Events Telegram group](https://t.me/pluralevents/969) or email [niko@hubsnetwork.org](mailto:niko@hubsnetwork.org).
+
+---
+
+*Plural Events are an initiative of [Hubs Network](https://www.hubsnetwork.org/), in partnership with [RadicalxChange](https://www.radicalxchange.org/), [Web3PrivacyNow](https://web3privacy.info/), [Logos](https://logos.co/), and [Comms Gardening](http://bit.ly/comms-gardening).*


### PR DESCRIPTION
## Summary
- New Updates announcement at [/updates/announcements/2026-04-host-a-plural-event/](https://www.radicalxchange.org/updates/announcements/2026-04-host-a-plural-event/) inviting RxC chapters to host parallel local events on May 14–15 around deliberative democracy, privacy, and collective action.
- Time-sensitive: organizer info session is **Thursday April 30, 4pm CET**, so this should ship today.
- Hero image to be added separately at `src/site/_images/announcements/newsletters/2026-04-host-a-plural-event/` (path matches the slug); body currently leads straight into copy.

## Test plan
- [ ] Verify post renders at `/updates/announcements/2026-04-host-a-plural-event/` on the deploy preview
- [ ] Confirm post appears at the top of `/updates/` listing alongside today's blog post
- [ ] Click each external link (Neocypherpunk Summit, luma.com/PluralEvents, info-session signup, Telegram group, niko@hubsnetwork.org mailto, Hubs Network, Logos, Web3PrivacyNow, Comms Gardening) — tracking params must be preserved
- [ ] Spot-check em/en dashes and smart quotes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)