### PR TITLE
Lower CWNYC highlights gates so the section renders during the week

### DIFF
--- a/scripts/test_update_cwnyc_highlights.py
+++ b/scripts/test_update_cwnyc_highlights.py
@@ -72,7 +72,7 @@ class SelectCardsTests(unittest.TestCase):
         self.assertEqual(uch.select_cards([], participants_count=100), [])
 
     def test_below_threshold_returns_empty(self):
-        # min_votes = max(20, 0.2 * 100) = 20. All comments below 20.
+        # min_votes = max(5, int(0.3 * 100)) = 30. Both comments below 30.
         stats = [_stat(0, 5, 1, 1), _stat(1, 4, 2, 2)]
         self.assertEqual(uch.select_cards(stats, participants_count=100), [])
 
@@ -124,7 +124,9 @@ class SelectCardsTests(unittest.TestCase):
     def test_rule_a_b_c_all_collide_yields_one_card(self):
         # Only one eligible comment — rule (a) takes it, rules (b) and (c)
         # find nothing to fall back to.
-        stats = [_stat(0, 18, 1, 1)]  # total 20 — exactly the floor
+        # min_votes at participants_count=100 is max(5, 30) = 30, so the
+        # comment needs total >= 30 to be eligible.
+        stats = [_stat(0, 28, 1, 1)]  # total 30 — exactly the threshold
         cards = uch.select_cards(stats, participants_count=100)
         self.assertEqual(len(cards), 1)
         self.assertEqual(cards[0]["label"], "Highest agreement")

--- a/scripts/update_cwnyc_highlights.py
+++ b/scripts/update_cwnyc_highlights.py
@@ -38,17 +38,20 @@ TIMEOUT_SECONDS = 30
 
 # Section-level safety gate. Below either threshold the script writes an
 # empty `statements` list — the template's hide-if-empty gate then keeps
-# the whole section off the page until the conversation has enough data
-# to be worth showing.
-MIN_TOTAL_VOTES = 50
-MIN_PARTICIPANTS = 10
+# the whole section off the page. Set to 0 during Community Week so the
+# section appears as soon as any individual statement clears the
+# per-statement floor below.
+MIN_TOTAL_VOTES = 0
+MIN_PARTICIPANTS = 0
 
-# Per-statement vote floor for cards. The ratio (20% of participants)
+# Per-statement vote floor for cards. The ratio (30% of participants)
 # scales with the conversation: as more people participate, the bar for a
-# card to appear rises proportionally. The hard floor (20) prevents
-# pulling cards from too thin a slice in early days.
-MIN_VOTES_PER_STATEMENT_FLOOR = 20
-MIN_VOTES_PER_STATEMENT_RATIO = 0.2
+# card to appear rises proportionally. The hard floor (5) prevents
+# pulling cards from too thin a slice in early days. At 17 participants
+# this gives a 5-vote threshold (int truncation of 5.1); at 100 it'd
+# give 30.
+MIN_VOTES_PER_STATEMENT_FLOOR = 5
+MIN_VOTES_PER_STATEMENT_RATIO = 0.3
 
 OUT_PATH = Path("src/site/_data/communityweekHighlights.json")
 


### PR DESCRIPTION
Section is rendering empty on production despite the conversation having 17 participants and 301 votes — the per-statement floor of 20 was blocking individual statements from being eligible (highest-voted statement currently at 11 votes). This drops the gates so the cards appear with current data.

## Changes

Four constants in [`scripts/update_cwnyc_highlights.py`](scripts/update_cwnyc_highlights.py):

| Constant | Old | New |
|---|---|---|
| `MIN_TOTAL_VOTES` | 50 | 0 |
| `MIN_PARTICIPANTS` | 10 | 0 |
| `MIN_VOTES_PER_STATEMENT_FLOOR` | 20 | 5 |
| `MIN_VOTES_PER_STATEMENT_RATIO` | 0.2 | 0.3 |

Per-statement gate is now `max(5, int(0.3 * participants))`. At 17 participants that's 5; at 100 it'd be 30. Keeps selection sane as the conversation grows without blocking cards now.

## Tests

Two updated, both for the new threshold value:
- `test_below_threshold_returns_empty` — comment updated to match new formula. Fixture passes unchanged.
- `test_rule_a_b_c_all_collide_yields_one_card` — fixture bumped from total 20 to total 30 so "exactly at the threshold" intent still holds.

All 13 tests pass locally. Collision-fallback and percentage-rounding paths unchanged.

## Dry-run

Three on-topic, typo-free cards selected from the live conversation:

| Card | Statement | Vote split | Total |
|---|---|---|---|
| Highest agreement | *"There should be a 'community economy' the way there is a creator economy, that is recognized and resourced"* | 86 / 0 / 14 | 7 |
| Most divided | *"The hardest part is what happens before and after events, not the events themselves"* | 34 / 33 / 33 | 9 |
| Most engaged | *"I've thought seriously about stopping my community work in the past year because of burnout"* | 18 / 46 / 36 | 11 |

The "Most engaged" card has a small agree share (it's the most-voted statement, not the most-agreed). The label means vote count; the bar communicates the breakdown honestly. Worth knowing this'll show on the live page.

## Note on threshold

`int(0.3 * 17) = 5`, not 6. Python `int()` truncates. If we want the threshold at 6 instead, swap to `math.ceil(...)` — one-line follow-up.

## After merge

Manually trigger the workflow on `main` from the Actions tab so the live page updates within minutes rather than waiting up to an hour for the next cron tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)