### PR TITLE
CWNYC: post-conversation report with Polis rep-comments algorithm

### DIFF
--- a/.github/workflows/update-cwnyc-highlights.yml
+++ b/.github/workflows/update-cwnyc-highlights.yml
@@ -1,23 +1,21 @@
 # Pulls live data from the public Polis CSV exports for conversation
 # 6epckxncim and writes src/site/_data/communityweekHighlights.json.
 # Netlify rebuilds on the resulting commit, so the page reflects the
-# latest snapshot within ~minutes of each scheduled run.
+# latest snapshot within ~minutes of each run.
 #
-# To take this offline mid-week (e.g. if Polis goes down or the data
-# looks weird and we need to freeze the page), comment out the
-# `schedule:` block below and push to main. The page will keep
-# showing whatever JSON was last committed until the cron is
-# re-enabled. `workflow_dispatch` stays available for manual triggers
-# either way.
+# Conversation closed 2026-05-14. Cron disabled — `workflow_dispatch`
+# only. Re-enable by uncommenting the schedule block below if the
+# conversation reopens (and bump the cron expression appropriately).
 #
-# GitHub will email the workflow author on scheduled-workflow failures
-# by default, so transient pol.is outages surface without extra config.
+# GitHub will email the workflow author on workflow failures by
+# default, so transient pol.is outages on manual runs surface without
+# extra config.
 
 name: Update CWNYC highlights
 
 on:
-  schedule:
-    - cron: "0 * * * *"  # hourly on the hour, UTC
+  # schedule:
+  #   - cron: "0 * * * *"  # hourly on the hour, UTC — disabled 2026-05-14
   workflow_dispatch: {}
 
 # Avoid overlapping runs if a scheduled run is still going when the
@@ -39,7 +37,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install --disable-pip-version-check requests==2.32.3 pandas==2.2.3
+        run: pip install --disable-pip-version-check requests==2.32.3 pandas==2.2.3 scipy==1.13.1
 
       - name: Run unit tests
         run: python -m unittest scripts/test_update_cwnyc_highlights.py

--- a/scripts/test_update_cwnyc_highlights.py
+++ b/scripts/test_update_cwnyc_highlights.py
@@ -1,11 +1,6 @@
 """Unit tests for scripts/update_cwnyc_highlights.py.
 
 Run with: python -m unittest scripts/test_update_cwnyc_highlights.py
-
-The selection logic is tested against fixture comment_stats lists
-(plain dicts) so the tests don't need pandas DataFrames or live network
-calls. compute_comment_stats() — which reads the dataframes — is
-indirectly exercised by the script's CI run.
 """
 
 from __future__ import annotations
@@ -14,6 +9,8 @@ import unittest
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+from scipy.stats import fisher_exact as _scipy_fisher
+
 _SPEC = spec_from_file_location(
     "uch", Path(__file__).resolve().parent / "update_cwnyc_highlights.py"
 )
@@ -21,15 +18,48 @@ uch = module_from_spec(_SPEC)
 _SPEC.loader.exec_module(uch)
 
 
-def _stat(cid: int, agree: int, disagree: int, pass_: int) -> dict:
+# ---- Helpers --------------------------------------------------------------
+
+
+def _stat(cid, agree, disagree, pass_, is_user=False):
     return {
         "comment_id": cid,
         "text": f"comment-{cid}",
+        "isUserSubmitted": is_user,
         "agree": agree,
         "disagree": disagree,
         "pass": pass_,
         "total": agree + disagree + pass_,
     }
+
+
+def _cg_stat(
+    cid, *,
+    g0_voted, g0_agree, g0_disagree, g0_pass,
+    g1_voted, g1_agree, g1_disagree, g1_pass,
+    is_user=False, text=None,
+):
+    """Construct a comment-group stat row mirroring parse_comment_groups()."""
+    return {
+        "comment_id": cid,
+        "text": text or f"comment-{cid}",
+        "isUserSubmitted": is_user,
+        "total": g0_voted + g1_voted,
+        "total_agree": g0_agree + g1_agree,
+        "total_disagree": g0_disagree + g1_disagree,
+        "total_pass": g0_pass + g1_pass,
+        "g0_voted": g0_voted,
+        "g0_agree": g0_agree,
+        "g0_disagree": g0_disagree,
+        "g0_pass": g0_pass,
+        "g1_voted": g1_voted,
+        "g1_agree": g1_agree,
+        "g1_disagree": g1_disagree,
+        "g1_pass": g1_pass,
+    }
+
+
+# ---- Existing percentage rounding ----------------------------------------
 
 
 class PercentagesTo100Tests(unittest.TestCase):
@@ -46,41 +76,33 @@ class PercentagesTo100Tests(unittest.TestCase):
         self.assertEqual(uch.percentages_to_100([50, 30, 20]), [50, 30, 20])
 
     def test_sums_to_100_with_remainders(self):
-        # 1, 1, 1 -> 33.33 each, floors 33+33+33=99, deficit 1 -> one
-        # entry gets +1. Output: total exactly 100.
         result = uch.percentages_to_100([1, 1, 1])
         self.assertEqual(sum(result), 100)
         self.assertIn(34, result)
         self.assertEqual(result.count(33), 2)
 
     def test_largest_remainder_picks_correctly(self):
-        # 7+13+7 = 27.
-        # Raw shares:    25.926, 48.148, 25.926
-        # Floors:        25, 48, 25  (sum 98, deficit 2)
-        # Remainders:    .926, .148, .926
-        # Largest two remainders are indexes 0 and 2 (tied at .926); deficit
-        # of 2 means BOTH get +1. Final: [26, 48, 26].
+        # 7+13+7=27 -> 25.93, 48.15, 25.93 -> floors 25,48,25=98, deficit 2,
+        # two largest remainders (indexes 0 and 2 at .926) each get +1.
         self.assertEqual(uch.percentages_to_100([7, 13, 7]), [26, 48, 26])
 
-    def test_negative_total_returns_zeros(self):
-        # Defensive: never blow up on degenerate input
+    def test_negative_or_zero_total(self):
         self.assertEqual(uch.percentages_to_100([0, 0]), [0, 0])
 
 
+# ---- Existing top-three card selection (unchanged logic, kept covered) ---
+
+
 class SelectCardsTests(unittest.TestCase):
-    def test_empty_input_returns_empty(self):
+    def test_empty_input(self):
         self.assertEqual(uch.select_cards([], participants_count=100), [])
 
     def test_below_threshold_returns_empty(self):
-        # min_votes = max(5, int(0.3 * 100)) = 30. Both comments below 30.
+        # min_votes = max(5, int(0.3*100)) = 30. Both stats below 30.
         stats = [_stat(0, 5, 1, 1), _stat(1, 4, 2, 2)]
         self.assertEqual(uch.select_cards(stats, participants_count=100), [])
 
     def test_three_distinct_winners(self):
-        # comment 0: highest agree% (95/100 = 95%), total 100
-        # comment 1: most divided (40 agree, 38 disagree on 80 -> gap 2.5%)
-        # comment 2: most engaged (total 120) — different from 0 because (0)
-        #            has total 100 < 120.
         stats = [
             _stat(0, 95, 3, 2),
             _stat(1, 40, 38, 2),
@@ -96,49 +118,295 @@ class SelectCardsTests(unittest.TestCase):
         self.assertEqual(cards[2]["text"], "comment-2")
 
     def test_rule_a_c_collision_falls_back_to_next_by_total(self):
-        # comment 0 has BOTH the highest agree share AND the highest total.
-        # When rule (a) takes comment 0, rule (c) must fall back to
-        # comment 1 (next-highest total among remaining eligible).
+        # Comment 0 has highest agree share AND highest total -> rule (c)
+        # falls back to next-highest total (comment 1).
         stats = [
-            _stat(0, 95, 3, 22),   # agree 76% (95/120), total 120 — highest both
-            _stat(1, 60, 5, 35),   # agree 60% (60/100), total 100 — second-highest total
-            _stat(2, 30, 28, 32),  # agree 33% (30/90),  total 90  — most divided
+            _stat(0, 95, 3, 22),  # agree 79%, total 120
+            _stat(1, 60, 5, 35),  # agree 60%, total 100
+            _stat(2, 30, 28, 32),  # gap 2/90 ~ 2%, total 90
         ]
         cards = uch.select_cards(stats, participants_count=100)
         self.assertEqual(len(cards), 3)
-
-        # Highest agreement -> comment 0 (76%, beats 60% and 33%)
-        self.assertEqual(cards[0]["label"], "Highest agreement")
         self.assertEqual(cards[0]["text"], "comment-0")
-
-        # Most divided -> comment 2 (gap = |30-28|/90 ~= 2%; way smaller
-        # than the others). Doesn't collide with rule (a).
-        self.assertEqual(cards[1]["label"], "Most divided")
         self.assertEqual(cards[1]["text"], "comment-2")
-
-        # Most engaged -> comment 1 (next-highest total at 100, since
-        # comment 0 is taken). This is the fallback path under test.
-        self.assertEqual(cards[2]["label"], "Most engaged")
         self.assertEqual(cards[2]["text"], "comment-1")
 
-    def test_rule_a_b_c_all_collide_yields_one_card(self):
-        # Only one eligible comment — rule (a) takes it, rules (b) and (c)
-        # find nothing to fall back to.
-        # min_votes at participants_count=100 is max(5, 30) = 30, so the
-        # comment needs total >= 30 to be eligible.
-        stats = [_stat(0, 28, 1, 1)]  # total 30 — exactly the threshold
+    def test_card_carries_isUserSubmitted_flag(self):
+        stats = [_stat(0, 28, 1, 1, is_user=True)]
         cards = uch.select_cards(stats, participants_count=100)
         self.assertEqual(len(cards), 1)
-        self.assertEqual(cards[0]["label"], "Highest agreement")
-        self.assertEqual(cards[0]["text"], "comment-0")
+        self.assertTrue(cards[0]["isUserSubmitted"])
 
-    def test_card_votes_are_percentages_summing_to_100(self):
-        stats = [_stat(0, 50, 30, 20), _stat(1, 40, 38, 22), _stat(2, 35, 30, 35)]
-        cards = uch.select_cards(stats, participants_count=100)
-        for c in cards:
-            v = c["votes"]
-            self.assertEqual(v["agree"] + v["disagree"] + v["pass"], 100)
-            self.assertEqual(v["total"], 100)
+
+# ---- Polis representative-comments algorithm ------------------------------
+
+
+class RepresentativenessTests(unittest.TestCase):
+    """Pseudocount-priored representativeness ratio: P_in/P_out where
+    P_x = (a + 1) / (n + 2)."""
+
+    def test_balanced_returns_one(self):
+        # 5/10 in-group vs 5/10 out-group -> P_in = 6/12 = .5, same for
+        # out -> R = 1.
+        r = uch.representativeness_with_priors(5, 10, 5, 10)
+        self.assertAlmostEqual(r, 1.0)
+
+    def test_in_group_much_higher(self):
+        # 9/10 in-group (P=.833) vs 1/10 out (P=.167) -> R=5.0
+        r = uch.representativeness_with_priors(9, 10, 1, 10)
+        self.assertAlmostEqual(r, (10 / 12) / (2 / 12))
+
+    def test_zero_in_group_with_priors(self):
+        # 0/5 in (P=1/7) vs 5/5 out (P=6/7) -> R = 1/6 ~ 0.167. The +1/+2
+        # priors keep the ratio finite (no div-by-zero).
+        r = uch.representativeness_with_priors(0, 5, 5, 5)
+        self.assertAlmostEqual(r, (1 / 7) / (6 / 7))
+
+    def test_zero_voted_either_side_does_not_explode(self):
+        # Edge case: nobody in either group voted on this comment. Priors
+        # still return a defined value (1/2 / 1/2 = 1).
+        r = uch.representativeness_with_priors(0, 0, 0, 0)
+        self.assertAlmostEqual(r, 1.0)
+
+
+class FisherExactTests(unittest.TestCase):
+    """Verify our wrapper matches scipy.stats.fisher_exact directly."""
+
+    def test_matches_scipy_two_tailed(self):
+        cases = [
+            (5, 10, 1, 10),   # in: 5/10, out: 1/10
+            (8, 8, 2, 23),    # tight one-sided table
+            (0, 10, 10, 10),  # extreme
+            (3, 10, 3, 10),   # null
+        ]
+        for in_a, in_v, out_a, out_v in cases:
+            with self.subTest(args=(in_a, in_v, out_a, out_v)):
+                table = [[in_a, in_v - in_a], [out_a, out_v - out_a]]
+                _, ref_p = _scipy_fisher(table, alternative="two-sided")
+                got = uch.fisher_p_two_tailed(in_a, in_v, out_a, out_v)
+                self.assertAlmostEqual(got, float(ref_p), places=10)
+
+    def test_degenerate_returns_one(self):
+        # Any zero row or column -> 1.0 (no information).
+        self.assertEqual(uch.fisher_p_two_tailed(0, 0, 5, 5), 1.0)
+        self.assertEqual(uch.fisher_p_two_tailed(0, 5, 0, 5), 1.0)
+
+
+class RepresentativeScoreTests(unittest.TestCase):
+    def test_strong_distinctive_high_score(self):
+        # In-group strongly agrees, out-group does not. Score = R * (1-p)
+        # should be substantially above 1 (R>>1) and (1-p) close to 1.
+        r, p, score = uch.representative_score(8, 8, 2, 23)
+        self.assertGreater(r, 5.0)
+        self.assertLess(p, 0.05)
+        self.assertGreater(score, 5.0)
+
+    def test_balanced_low_score(self):
+        # No distinction -> R~1, p~1, score~0.
+        r, p, score = uch.representative_score(5, 10, 5, 10)
+        self.assertAlmostEqual(r, 1.0)
+        self.assertGreater(p, 0.9)
+        self.assertLess(score, 0.2)
+
+
+# ---- Per-group representative selection ----------------------------------
+
+
+class SelectRepresentativePerGroupTests(unittest.TestCase):
+    def test_groups_eq_1_returns_empty(self):
+        # Edge case: single-group conversation. comment-groups.csv only
+        # supports the 2-group schema; we short-circuit cleanly.
+        stats = [_cg_stat(0, g0_voted=5, g0_agree=4, g0_disagree=0, g0_pass=1,
+                          g1_voted=0, g1_agree=0, g1_disagree=0, g1_pass=0)]
+        self.assertEqual(
+            uch.select_representative_per_group(stats, groups_count=1), []
+        )
+
+    def test_low_in_group_voters_are_filtered(self):
+        # Comment 0: only 3 group-0 voters -> below MIN_IN_GROUP_VOTERS (4)
+        # -> dropped from group-0 candidate set. Group-1 still picks it
+        # because group-1 has plenty of voters.
+        stats = [
+            _cg_stat(
+                0,
+                g0_voted=3, g0_agree=3, g0_disagree=0, g0_pass=0,
+                g1_voted=10, g1_agree=2, g1_disagree=7, g1_pass=1,
+            ),
+            _cg_stat(
+                1,
+                g0_voted=6, g0_agree=5, g0_disagree=0, g0_pass=1,
+                g1_voted=8, g1_agree=1, g1_disagree=6, g1_pass=1,
+            ),
+        ]
+        groups = uch.select_representative_per_group(stats, groups_count=2)
+        # Group 0 should not contain comment 0 (filtered out by noise floor)
+        g0 = next(g for g in groups if g["id"] == 0)
+        g0_comment_texts = {s["text"] for s in g0["representativeStatements"]}
+        self.assertNotIn("comment-0", g0_comment_texts)
+
+    def test_picks_distinct_comments_per_group(self):
+        # 3 comments, each strongly distinctive for one direction. Verify
+        # each group gets back its strongest signals.
+        stats = [
+            # Comment 0: group 0 strongly agrees; group 1 disagrees
+            _cg_stat(
+                0,
+                g0_voted=8, g0_agree=8, g0_disagree=0, g0_pass=0,
+                g1_voted=20, g1_agree=2, g1_disagree=16, g1_pass=2,
+            ),
+            # Comment 1: group 0 strongly disagrees; group 1 agrees
+            _cg_stat(
+                1,
+                g0_voted=8, g0_agree=0, g0_disagree=7, g0_pass=1,
+                g1_voted=20, g1_agree=18, g1_disagree=1, g1_pass=1,
+            ),
+            # Comment 2: balanced (no distinction)
+            _cg_stat(
+                2,
+                g0_voted=8, g0_agree=4, g0_disagree=3, g0_pass=1,
+                g1_voted=20, g1_agree=10, g1_disagree=8, g1_pass=2,
+            ),
+        ]
+        groups = uch.select_representative_per_group(
+            stats, groups_count=2, per_group=2
+        )
+        self.assertEqual(len(groups), 2)
+
+        # Group 0's top two should be comment 0 (agree) and comment 1 (disagree)
+        g0 = next(g for g in groups if g["id"] == 0)
+        g0_ids = {s["text"] for s in g0["representativeStatements"]}
+        self.assertEqual(g0_ids, {"comment-0", "comment-1"})
+        # And the vote types should be opposite (one agree, one disagree)
+        g0_votes = {(s["text"], s["voteType"]) for s in g0["representativeStatements"]}
+        self.assertIn(("comment-0", "agree"), g0_votes)
+        self.assertIn(("comment-1", "disagree"), g0_votes)
+
+        # Group 1's signs should be flipped on the same comments
+        g1 = next(g for g in groups if g["id"] == 1)
+        g1_votes = {(s["text"], s["voteType"]) for s in g1["representativeStatements"]}
+        self.assertIn(("comment-0", "disagree"), g1_votes)
+        self.assertIn(("comment-1", "agree"), g1_votes)
+
+
+# ---- Consensus / divisive ------------------------------------------------
+
+
+class ConsensusDivisiveTests(unittest.TestCase):
+    def test_consensus_picks_minimum_across_groups(self):
+        # Comment 0: both groups strongly agree -> consensus
+        # Comment 1: group 0 agrees, group 1 doesn't -> not consensus
+        # Comment 2: both groups partly agree but neither very strongly
+        stats = [
+            _cg_stat(
+                0,
+                g0_voted=8, g0_agree=7, g0_disagree=0, g0_pass=1,
+                g1_voted=20, g1_agree=17, g1_disagree=1, g1_pass=2,
+            ),
+            _cg_stat(
+                1,
+                g0_voted=8, g0_agree=7, g0_disagree=0, g0_pass=1,
+                g1_voted=20, g1_agree=4, g1_disagree=14, g1_pass=2,
+            ),
+            _cg_stat(
+                2,
+                g0_voted=8, g0_agree=4, g0_disagree=2, g0_pass=2,
+                g1_voted=20, g1_agree=10, g1_disagree=6, g1_pass=4,
+            ),
+        ]
+        consensus = uch.select_consensus(stats, min_votes=8, top_n=5)
+        self.assertEqual(len(consensus), 3)
+        # Comment 0 should be first (min agree rate is the highest)
+        self.assertEqual(consensus[0]["comment_id"], 0)
+
+    def test_consensus_respects_min_votes(self):
+        # Comment 0: high min-group agree rate but only 5 total votes
+        # (below min_votes=10) -> excluded.
+        stats = [
+            _cg_stat(
+                0,
+                g0_voted=2, g0_agree=2, g0_disagree=0, g0_pass=0,
+                g1_voted=3, g1_agree=3, g1_disagree=0, g1_pass=0,
+            ),
+        ]
+        self.assertEqual(uch.select_consensus(stats, min_votes=10), [])
+
+    def test_divisive_picks_largest_gap(self):
+        # Three comments:
+        # 0: g0 92% agree, g1 10% agree -> gap 82pp (highest)
+        # 1: g0 50% agree, g1 30% agree -> gap 20pp
+        # 2: g0 25% agree, g1 25% agree -> gap 0pp (consensus, not divisive)
+        stats = [
+            _cg_stat(
+                0,
+                g0_voted=12, g0_agree=11, g0_disagree=0, g0_pass=1,
+                g1_voted=20, g1_agree=2, g1_disagree=16, g1_pass=2,
+            ),
+            _cg_stat(
+                1,
+                g0_voted=10, g0_agree=5, g0_disagree=2, g0_pass=3,
+                g1_voted=10, g1_agree=3, g1_disagree=4, g1_pass=3,
+            ),
+            _cg_stat(
+                2,
+                g0_voted=8, g0_agree=2, g0_disagree=4, g0_pass=2,
+                g1_voted=8, g1_agree=2, g1_disagree=4, g1_pass=2,
+            ),
+        ]
+        divisive = uch.select_divisive(stats, min_votes=5, top_n=3)
+        self.assertEqual(len(divisive), 3)
+        self.assertEqual(divisive[0]["comment_id"], 0)
+
+    def test_divisive_skips_comments_with_empty_group(self):
+        # Comment 0 has zero group-0 voters -> gap is undefined -> dropped.
+        # Comment 1 has both groups -> included.
+        stats = [
+            _cg_stat(
+                0,
+                g0_voted=0, g0_agree=0, g0_disagree=0, g0_pass=0,
+                g1_voted=10, g1_agree=10, g1_disagree=0, g1_pass=0,
+            ),
+            _cg_stat(
+                1,
+                g0_voted=6, g0_agree=5, g0_disagree=0, g0_pass=1,
+                g1_voted=6, g1_agree=0, g1_disagree=5, g1_pass=1,
+            ),
+        ]
+        divisive = uch.select_divisive(stats, min_votes=5)
+        self.assertEqual(len(divisive), 1)
+        self.assertEqual(divisive[0]["comment_id"], 1)
+
+
+# ---- Output shape: isUserSubmitted propagates --------------------------
+
+
+class IsUserSubmittedPropagationTests(unittest.TestCase):
+    def test_consensus_card_carries_flag(self):
+        stats = [
+            _cg_stat(
+                0,
+                g0_voted=8, g0_agree=7, g0_disagree=0, g0_pass=1,
+                g1_voted=20, g1_agree=17, g1_disagree=1, g1_pass=2,
+                is_user=True,
+            ),
+        ]
+        consensus = uch.select_consensus(stats, min_votes=8)
+        cards = [uch._consensus_card(r) for r in consensus]
+        self.assertEqual(len(cards), 1)
+        self.assertTrue(cards[0]["isUserSubmitted"])
+
+    def test_divisive_card_carries_flag(self):
+        stats = [
+            _cg_stat(
+                0,
+                g0_voted=8, g0_agree=7, g0_disagree=0, g0_pass=1,
+                g1_voted=20, g1_agree=2, g1_disagree=16, g1_pass=2,
+                is_user=False,
+            ),
+        ]
+        divisive = uch.select_divisive(stats, min_votes=5)
+        cards = [uch._divisive_card(r) for r in divisive]
+        self.assertEqual(len(cards), 1)
+        self.assertFalse(cards[0]["isUserSubmitted"])
 
 
 if __name__ == "__main__":

--- a/scripts/update_cwnyc_highlights.py
+++ b/scripts/update_cwnyc_highlights.py
@@ -1,15 +1,27 @@
 #!/usr/bin/env python3
-"""Build src/site/_data/communityweekHighlights.json from live Polis exports.
+"""Build src/site/_data/communityweekHighlights.json from Polis exports.
 
 Pulls public CSV exports for conversation 6epckxncim / report
-r45wsbrxmtk78wndwbhpm and writes the small JSON file that
+r45wsbrxmtk78wndwbhpm and writes the JSON file that
 src/site/communityweeknyc/index.njk reads.
 
-Run by .github/workflows/update-cwnyc-highlights.yml on a 4-hour cron.
+The conversation closed on 2026-05-14. This script now produces a
+post-conversation report including:
+
+- `topStatements`: the original three at-a-glance cards (highest
+  agreement / most divided / most engaged)
+- `consensus`: top 5 statements with the highest minimum-across-groups
+  agree rate (i.e. agreed-on by both opinion groups)
+- `divisive`: top 3 statements with the largest agree-rate gap between
+  the two opinion groups
+- `groups`: per-group representative statements computed using Polis's
+  documented representative-comments algorithm
+  (https://compdemocracy.org/representative-comments/) — Laplace-
+  smoothed group-vs-complement representativeness ratio combined with
+  Fisher's exact test p-value
 
 If the substantive content matches what's already on disk, lastUpdated
-is preserved so `git diff` sees no change and the workflow skips the
-commit.
+is preserved so `git diff` sees no change.
 
 Data source: Polis CSV exports, licensed CC BY 4.0 to The Computational
 Democracy Project (https://compdemocracy.org/).
@@ -29,6 +41,7 @@ from typing import Any, Callable
 
 import pandas as pd
 import requests
+from scipy.stats import fisher_exact
 
 # ---- Constants -------------------------------------------------------------
 
@@ -37,21 +50,31 @@ EXPORT_BASE = f"https://pol.is/api/v3/reportExport/{REPORT_ID}"
 TIMEOUT_SECONDS = 30
 
 # Section-level safety gate. Below either threshold the script writes an
-# empty `statements` list — the template's hide-if-empty gate then keeps
-# the whole section off the page. Set to 0 during Community Week so the
-# section appears as soon as any individual statement clears the
-# per-statement floor below.
+# empty `topStatements` list — the template's hide-if-empty gate then
+# keeps the whole section off the page.
 MIN_TOTAL_VOTES = 0
 MIN_PARTICIPANTS = 0
 
-# Per-statement vote floor for cards. The ratio (30% of participants)
-# scales with the conversation: as more people participate, the bar for a
-# card to appear rises proportionally. The hard floor (5) prevents
-# pulling cards from too thin a slice in early days. At 17 participants
-# this gives a 5-vote threshold (int truncation of 5.1); at 100 it'd
-# give 30.
+# Per-statement vote floor for the top three at-a-glance cards. The
+# ratio scales with the conversation; the hard floor protects against
+# pulling cards from too thin a slice. Uses `voters` (everyone who cast
+# any vote) as the participant base — same as before.
 MIN_VOTES_PER_STATEMENT_FLOOR = 5
 MIN_VOTES_PER_STATEMENT_RATIO = 0.3
+
+# Min-votes threshold for consensus/divisive selection. Uses
+# `voters_in_conv` (the population Polis itself uses for analysis —
+# people who voted on enough comments to be assigned a group), not
+# `voters`. ceil() so that "25% of voters_in_conv" rounds up — at 31
+# voters_in_conv this gives 8.
+def min_votes_for_findings(voters_in_conv: int) -> int:
+    return max(5, math.ceil(0.25 * voters_in_conv))
+
+# Noise filter for per-group representative statements: a statement
+# with fewer than this many in-group voters is dropped from the
+# candidate set before ranking. Better 2 strong cards per group than 3
+# with one being noise from a small sample.
+MIN_IN_GROUP_VOTERS = 4
 
 OUT_PATH = Path("src/site/_data/communityweekHighlights.json")
 
@@ -93,9 +116,7 @@ def fetch_summary() -> dict[str, str]:
 def percentages_to_100(parts: list[int]) -> list[int]:
     """Convert raw counts to integer percentages summing to 100.
 
-    Largest-remainder method: floor each share, then distribute the
-    leftover percentage points to the entries with the largest fractional
-    remainders. Returns all zeros if input is empty or sums to zero.
+    Largest-remainder rounding. Empty or zero-sum input returns zeros.
     """
     total = sum(parts)
     if total <= 0:
@@ -119,13 +140,8 @@ def compute_comment_stats(
     comments_df: pd.DataFrame,
     vote_matrix: pd.DataFrame,
 ) -> list[dict[str, Any]]:
-    """Build per-comment vote stats from comments.csv + participant-votes.csv.
-
-    Excludes comments with `moderated < 0` (removed). `vote_matrix` is the
-    wide-format participant-votes.csv with per-comment columns named "0",
-    "1", …, "N-1" — vote codes 1=agree, -1=disagree, 0=pass, blank=not
-    yet voted.
-    """
+    """Per-comment vote stats for moderated>=0 comments (used by the
+    top three cards). isUserSubmitted is true when author-id != 0."""
     out: list[dict[str, Any]] = []
     for _, c in comments_df.iterrows():
         if c["moderated"] < 0:
@@ -143,6 +159,7 @@ def compute_comment_stats(
             {
                 "comment_id": cid,
                 "text": str(c["comment-body"]),
+                "isUserSubmitted": int(c["author-id"]) != 0,
                 "agree": agree,
                 "disagree": disagree,
                 "pass": pass_,
@@ -159,6 +176,7 @@ def _build_card(label: str, c: dict[str, Any]) -> dict[str, Any]:
     return {
         "label": label,
         "text": c["text"],
+        "isUserSubmitted": c["isUserSubmitted"],
         "votes": {
             "agree": pct_agree,
             "disagree": pct_disagree,
@@ -172,20 +190,16 @@ def select_cards(
     comment_stats: list[dict[str, Any]],
     participants_count: int,
 ) -> list[dict[str, Any]]:
-    """Select up to 3 statement cards by the three rules.
-
-    All three rules are gated by the same per-statement vote threshold
-    so a card only appears once at least one statement has crossed a
-    real engagement bar. If two rules pick the same comment, the second
-    occurrence falls back to the next-best by that rule's criterion.
-    """
+    """Select up to 3 at-a-glance cards: highest agreement / most
+    divided / most engaged. Same logic as before. Collisions fall back
+    to next-best by that rule's criterion."""
     min_votes = max(
         MIN_VOTES_PER_STATEMENT_FLOOR,
         int(MIN_VOTES_PER_STATEMENT_RATIO * participants_count),
     )
     eligible = [r for r in comment_stats if r["total"] >= min_votes]
     log.info(
-        "Eligibility threshold: %d votes per statement; %d/%d statements eligible",
+        "Top-card eligibility: %d votes/statement; %d/%d statements eligible",
         min_votes,
         len(eligible),
         len(comment_stats),
@@ -194,11 +208,7 @@ def select_cards(
     cards: list[dict[str, Any]] = []
     used: set[int] = set()
 
-    def pick(
-        label: str,
-        sort_key: Callable[[dict[str, Any]], Any],
-        why: Callable[[dict[str, Any]], str],
-    ) -> None:
+    def pick(label: str, sort_key, why) -> None:
         for c in sorted(eligible, key=sort_key):
             if c["comment_id"] in used:
                 continue
@@ -208,36 +218,309 @@ def select_cards(
             return
         log.info("%s: no eligible comment", label)
 
-    # (a) Highest agreement: agree fraction desc; total desc as tie-break
     pick(
         "Highest agreement",
         lambda r: (-(r["agree"] / r["total"]), -r["total"]),
-        lambda c: f"{c['agree']}/{c['total']} = {100 * c['agree'] / c['total']:.0f}% agree",
+        lambda c: f"{c['agree']}/{c['total']} = {100*c['agree']/c['total']:.0f}% agree",
     )
-
-    # (b) Most divided: smallest |agree-disagree| share; total desc as tie-break
     pick(
         "Most divided",
-        lambda r: (
-            abs(r["agree"] - r["disagree"]) / r["total"],
-            -r["total"],
-        ),
-        lambda c: (
-            f"|agree-disagree| = "
-            f"{abs(c['agree'] - c['disagree']) / c['total']:.2f}, total {c['total']}"
-        ),
+        lambda r: (abs(r["agree"] - r["disagree"]) / r["total"], -r["total"]),
+        lambda c: f"|a-d|/total = {abs(c['agree']-c['disagree'])/c['total']:.2f}, total {c['total']}",
     )
-
-    # (c) Most engaged: highest total vote count, gated by min_votes too —
-    # so the card only appears once a statement has cleared a real bar,
-    # not just edged out very-low-vote peers in the first hours.
     pick(
         "Most engaged",
         lambda r: -r["total"],
         lambda c: f"{c['total']} total votes",
     )
-
     return cards
+
+
+# ---- Per-comment per-group analysis ---------------------------------------
+
+
+def parse_comment_groups(
+    comments_df: pd.DataFrame,
+    comment_groups_df: pd.DataFrame,
+) -> list[dict[str, Any]]:
+    """Join comment-groups.csv with comments.csv and produce one dict
+    per visible (moderated>=0) comment with per-group vote breakdowns.
+
+    Assumes the standard Polis 2-group export schema: comment-groups.csv
+    has `group-a-*` and `group-b-*` columns mapping to participant-votes
+    group-id 0 and 1 respectively.
+    """
+    moderated_ok = comments_df[comments_df["moderated"] >= 0][
+        ["comment-id", "author-id", "comment-body"]
+    ]
+    merged = comment_groups_df.merge(moderated_ok, on="comment-id", how="inner")
+
+    out: list[dict[str, Any]] = []
+    for _, r in merged.iterrows():
+        ga_v = int(r["group-a-votes"])
+        gb_v = int(r["group-b-votes"])
+        ga_a = int(r["group-a-agrees"])
+        ga_d = int(r["group-a-disagrees"])
+        ga_p = int(r["group-a-passes"])
+        gb_a = int(r["group-b-agrees"])
+        gb_d = int(r["group-b-disagrees"])
+        gb_p = int(r["group-b-passes"])
+        total_v = int(r["total-votes"])
+        total_a = int(r["total-agrees"])
+        total_d = int(r["total-disagrees"])
+        total_p = int(r["total-passes"])
+        out.append(
+            {
+                "comment_id": int(r["comment-id"]),
+                "text": str(r["comment-body"]),
+                "isUserSubmitted": int(r["author-id"]) != 0,
+                "total": total_v,
+                "total_agree": total_a,
+                "total_disagree": total_d,
+                "total_pass": total_p,
+                # Per-group counts: g0 = group A, g1 = group B
+                "g0_voted": ga_v,
+                "g0_agree": ga_a,
+                "g0_disagree": ga_d,
+                "g0_pass": ga_p,
+                "g1_voted": gb_v,
+                "g1_agree": gb_a,
+                "g1_disagree": gb_d,
+                "g1_pass": gb_p,
+            }
+        )
+    return out
+
+
+# ---- Polis representative-comments algorithm ------------------------------
+
+
+def representativeness_with_priors(
+    in_a: int, in_voted: int, out_a: int, out_voted: int
+) -> float:
+    """Laplace-smoothed representativeness ratio.
+
+    P_v(g, c) = (N_a_v + 1) / (N_v + 2). The +1/+2 Laplace pseudocounts
+    keep the ratio finite when either group has zero votes of type v
+    and avoid wild ratios on small denominators.
+    """
+    p_in = (in_a + 1) / (in_voted + 2)
+    p_out = (out_a + 1) / (out_voted + 2)
+    return p_in / p_out
+
+
+def fisher_p_two_tailed(
+    in_a: int, in_voted: int, out_a: int, out_voted: int
+) -> float:
+    """Two-sided Fisher's exact test p-value for the 2x2 table:
+
+        in-group:    voted_v=in_a    not_v=in_voted-in_a
+        out-group:   voted_v=out_a   not_v=out_voted-out_a
+
+    The "not_v" cells include both opposite-vote AND pass — i.e.
+    everything that wasn't a vote of type v. Returns 1.0 on a degenerate
+    table (zero-row or zero-column) — those should never beat any well-
+    formed pairing on the score anyway.
+    """
+    a = in_a
+    b = in_voted - in_a
+    c = out_a
+    d = out_voted - out_a
+    if a + b == 0 or c + d == 0 or a + c == 0 or b + d == 0:
+        return 1.0
+    _, p = fisher_exact([[a, b], [c, d]], alternative="two-sided")
+    return float(p)
+
+
+def representative_score(
+    in_a: int, in_voted: int, out_a: int, out_voted: int
+) -> tuple[float, float, float]:
+    """Returns (R, p, score). score = R * (1 - p)."""
+    r = representativeness_with_priors(in_a, in_voted, out_a, out_voted)
+    p = fisher_p_two_tailed(in_a, in_voted, out_a, out_voted)
+    return r, p, r * (1 - p)
+
+
+# ---- Consensus / divisive / per-group selection ---------------------------
+
+
+def select_consensus(
+    cg_stats: list[dict[str, Any]],
+    min_votes: int,
+    top_n: int = 5,
+) -> list[dict[str, Any]]:
+    """Statements with the highest minimum-across-groups agree rate.
+
+    `min` (not mean) of the two group agree rates: a statement only
+    counts as consensus if BOTH groups actually agreed at a high rate.
+    """
+    candidates = [r for r in cg_stats if r["total"] >= min_votes]
+    enriched = []
+    for r in candidates:
+        # Agree rate per group (denominator = group voters who voted at all)
+        g0_rate = r["g0_agree"] / r["g0_voted"] if r["g0_voted"] > 0 else 0.0
+        g1_rate = r["g1_agree"] / r["g1_voted"] if r["g1_voted"] > 0 else 0.0
+        enriched.append(
+            {
+                **r,
+                "g0_agree_rate": g0_rate,
+                "g1_agree_rate": g1_rate,
+                "min_group_agree_rate": min(g0_rate, g1_rate),
+            }
+        )
+    enriched.sort(key=lambda r: (-r["min_group_agree_rate"], -r["total"]))
+    return enriched[:top_n]
+
+
+def select_divisive(
+    cg_stats: list[dict[str, Any]],
+    min_votes: int,
+    top_n: int = 3,
+) -> list[dict[str, Any]]:
+    """Statements with the largest absolute gap in agree rate between
+    groups. Both groups must have at least one voter on the comment
+    (otherwise the gap is meaningless)."""
+    candidates = [
+        r
+        for r in cg_stats
+        if r["total"] >= min_votes and r["g0_voted"] > 0 and r["g1_voted"] > 0
+    ]
+    enriched = []
+    for r in candidates:
+        g0_rate = r["g0_agree"] / r["g0_voted"]
+        g1_rate = r["g1_agree"] / r["g1_voted"]
+        enriched.append(
+            {
+                **r,
+                "g0_agree_rate": g0_rate,
+                "g1_agree_rate": g1_rate,
+                "agree_rate_gap": abs(g0_rate - g1_rate),
+            }
+        )
+    enriched.sort(key=lambda r: (-r["agree_rate_gap"], -r["total"]))
+    return enriched[:top_n]
+
+
+def select_representative_per_group(
+    cg_stats: list[dict[str, Any]],
+    groups_count: int,
+    per_group: int = 3,
+    group_sizes: dict[int, int] | None = None,
+) -> list[dict[str, Any]]:
+    """For each group in [0, groups_count): rank all (statement, vote
+    type) pairs by representativeness score and take the top
+    `per_group` distinct statements (across both vote types) that pass
+    the in-group noise filter.
+
+    `group_sizes`: optional dict mapping group_id -> participant count.
+    If supplied, used for the rendered `size`. Otherwise we fall back
+    to max(in_voted across comments), which undercounts when not every
+    member of a group voted on a single comment.
+
+    If groups_count != 2, returns []: this implementation reads
+    comment-groups.csv columns hardcoded to 2 groups.
+    """
+    if groups_count != 2:
+        log.info(
+            "Skipping per-group selection: groups_count=%d != 2. "
+            "The 2-group case is the only one comment-groups.csv supports.",
+            groups_count,
+        )
+        return []
+
+    groups_out: list[dict[str, Any]] = []
+    for g in (0, 1):
+        in_prefix = "g0" if g == 0 else "g1"
+        out_prefix = "g1" if g == 0 else "g0"
+
+        candidates: list[dict[str, Any]] = []
+        for r in cg_stats:
+            in_voted = r[f"{in_prefix}_voted"]
+            if in_voted < MIN_IN_GROUP_VOTERS:
+                continue  # noise filter
+            for vote_type, in_a_key, out_a_key in (
+                ("agree", "agree", "agree"),
+                ("disagree", "disagree", "disagree"),
+            ):
+                in_a = r[f"{in_prefix}_{in_a_key}"]
+                out_a = r[f"{out_prefix}_{out_a_key}"]
+                out_voted = r[f"{out_prefix}_voted"]
+                rep_r, p, score = representative_score(
+                    in_a, in_voted, out_a, out_voted
+                )
+                in_rate = in_a / in_voted if in_voted > 0 else 0.0
+                out_rate = out_a / out_voted if out_voted > 0 else 0.0
+                candidates.append(
+                    {
+                        "comment_id": r["comment_id"],
+                        "text": r["text"],
+                        "isUserSubmitted": r["isUserSubmitted"],
+                        "voteType": vote_type,
+                        "inGroupRate": round(in_rate, 4),
+                        "outGroupRate": round(out_rate, 4),
+                        "inGroupN": in_voted,
+                        "outGroupN": out_voted,
+                        "R": round(rep_r, 4),
+                        "p": round(p, 4),
+                        "score": round(score, 4),
+                    }
+                )
+
+        # Rank by score desc; pick top per_group distinct comment_ids
+        candidates.sort(key=lambda c: -c["score"])
+        chosen: list[dict[str, Any]] = []
+        chosen_ids: set[int] = set()
+        for c in candidates:
+            if c["comment_id"] in chosen_ids:
+                continue
+            chosen.append(c)
+            chosen_ids.add(c["comment_id"])
+            log.info(
+                "Group %d: comment-id=%d (%s, R=%.2f, p=%.3f, in=%d/%d, out=%d/%d)",
+                g,
+                c["comment_id"],
+                c["voteType"],
+                c["R"],
+                c["p"],
+                int(c["inGroupRate"] * c["inGroupN"]),
+                c["inGroupN"],
+                int(c["outGroupRate"] * c["outGroupN"]),
+                c["outGroupN"],
+            )
+            if len(chosen) >= per_group:
+                break
+
+        # Group size: prefer the authoritative count from
+        # participant-votes.csv if caller passed it in. Fall back to
+        # max(in_voted) across comments — that undercounts when not
+        # every group member voted on a single comment.
+        if group_sizes is not None and g in group_sizes:
+            size = int(group_sizes[g])
+        else:
+            size = int(max(
+                (r[f"{in_prefix}_voted"] for r in cg_stats), default=0
+            ))
+
+        groups_out.append(
+            {
+                "id": g,
+                "size": size,
+                "representativeStatements": [
+                    {
+                        "text": c["text"],
+                        "isUserSubmitted": c["isUserSubmitted"],
+                        "voteType": c["voteType"],
+                        "inGroupRate": c["inGroupRate"],
+                        "outGroupRate": c["outGroupRate"],
+                        "inGroupN": c["inGroupN"],
+                        "outGroupN": c["outGroupN"],
+                        "score": c["score"],
+                    }
+                    for c in chosen
+                ],
+            }
+        )
+    return groups_out
 
 
 # ---- Output ----------------------------------------------------------------
@@ -248,9 +531,9 @@ def now_iso() -> str:
 
 
 def merge_lastupdated(payload: dict[str, Any]) -> dict[str, Any]:
-    """If everything except `lastUpdated` matches what's on disk, retain
-    the existing timestamp so the workflow's byte-equality check skips
-    the commit."""
+    """If everything except lastUpdated matches what's on disk, retain
+    the existing timestamp so the workflow's byte-equality check
+    skips the commit."""
     fresh = now_iso()
     if not OUT_PATH.exists():
         payload["lastUpdated"] = fresh
@@ -277,6 +560,46 @@ def write_payload(payload: dict[str, Any]) -> None:
     log.info("Wrote %s", OUT_PATH)
 
 
+# ---- Output shaping for JSON ----------------------------------------------
+
+
+def _consensus_card(r: dict[str, Any]) -> dict[str, Any]:
+    pct_a, pct_d, pct_p = percentages_to_100(
+        [r["total_agree"], r["total_disagree"], r["total_pass"]]
+    )
+    return {
+        "text": r["text"],
+        "isUserSubmitted": r["isUserSubmitted"],
+        "votes": {
+            "agree": pct_a,
+            "disagree": pct_d,
+            "pass": pct_p,
+            "total": r["total"],
+        },
+        "minGroupAgreeRate": round(r["min_group_agree_rate"], 4),
+    }
+
+
+def _divisive_card(r: dict[str, Any]) -> dict[str, Any]:
+    pct_a, pct_d, pct_p = percentages_to_100(
+        [r["total_agree"], r["total_disagree"], r["total_pass"]]
+    )
+    return {
+        "text": r["text"],
+        "isUserSubmitted": r["isUserSubmitted"],
+        "votes": {
+            "agree": pct_a,
+            "disagree": pct_d,
+            "pass": pct_p,
+            "total": r["total"],
+        },
+        "groupAgreeRates": [
+            {"groupId": 0, "rate": round(r["g0_agree_rate"], 4), "n": r["g0_voted"]},
+            {"groupId": 1, "rate": round(r["g1_agree_rate"], 4), "n": r["g1_voted"]},
+        ],
+    }
+
+
 # ---- Main ------------------------------------------------------------------
 
 
@@ -284,57 +607,96 @@ def main() -> int:
     try:
         summary = fetch_summary()
         comments = fetch_table("comments")
-        votes = fetch_table("participant-votes")
+        vote_matrix = fetch_table("participant-votes")
+        comment_groups = fetch_table("comment-groups")
+        # Also fetched per spec; not currently consumed (comment-groups.csv
+        # has the per-group aggregates we need).
+        fetch_table("votes")
     except Exception as e:
         log.error("Fetch failed: %s", e)
         return 1
 
-    # `summary.csv:voters` = "people who cast >=1 vote", NOT "people who
-    # loaded the page". This is the count we display as `participants` and
-    # also the denominator for the per-statement min-vote ratio.
     voters = int(summary.get("voters", 0))
+    voters_in_conv = int(summary.get("voters-in-conv", 0))
+    commenters = int(summary.get("commenters", 0))
+    groups_count = int(summary.get("groups", 0))
 
-    # Total votes cast = sum of n-votes across all participants in
-    # participant-votes.csv. summary.csv doesn't expose this.
-    total_votes = (
-        int(votes["n-votes"].sum()) if "n-votes" in votes.columns else 0
-    )
-
-    # Statement count = comments visible to participants (moderated >= 0).
-    # summary.csv:comments is the same number when nothing's been removed,
-    # but counting from comments.csv directly keeps a single source for
-    # both stats.statements and the card-selection eligible set.
+    total_votes = int(vote_matrix["n-votes"].sum()) if "n-votes" in vote_matrix.columns else 0
     statements_count = (
-        int((comments["moderated"] >= 0).sum())
-        if "moderated" in comments.columns
-        else 0
+        int((comments["moderated"] >= 0).sum()) if "moderated" in comments.columns else 0
     )
 
     log.info(
-        "voters=%d total_votes=%d statements=%d",
-        voters,
-        total_votes,
-        statements_count,
+        "voters=%d voters_in_conv=%d commenters=%d statements=%d groups=%d total_votes=%d",
+        voters, voters_in_conv, commenters, statements_count, groups_count, total_votes,
     )
 
     if total_votes < MIN_TOTAL_VOTES or voters < MIN_PARTICIPANTS:
-        log.info(
-            "Below safety gate (need votes>=%d AND participants>=%d). "
-            "Writing empty state.",
-            MIN_TOTAL_VOTES,
-            MIN_PARTICIPANTS,
-        )
-        payload: dict[str, Any] = {"stats": None, "statements": []}
+        log.info("Below safety gate. Writing empty state.")
+        payload: dict[str, Any] = {
+            "conversationClosed": True,
+            "consensus": [],
+            "divisive": [],
+            "groups": [],
+            "stats": None,
+            "topStatements": [],
+        }
     else:
-        comment_stats = compute_comment_stats(comments, votes)
-        cards = select_cards(comment_stats, voters)
+        # Top three at-a-glance cards (existing logic; uses participant-votes
+        # for per-vote breakdowns including pass counts).
+        comment_stats = compute_comment_stats(comments, vote_matrix)
+        top_cards = select_cards(comment_stats, voters)
+
+        # Per-group analysis source.
+        cg_stats = parse_comment_groups(comments, comment_groups)
+        min_findings_votes = min_votes_for_findings(voters_in_conv)
+        log.info(
+            "Consensus/divisive eligibility: votes>=%d (max(5, ceil(0.25*%d)))",
+            min_findings_votes, voters_in_conv,
+        )
+
+        consensus_rows = select_consensus(cg_stats, min_findings_votes, top_n=5)
+        for r in consensus_rows:
+            log.info(
+                "Consensus: comment-id=%d (min group agree=%.0f%%, total=%d)",
+                r["comment_id"], r["min_group_agree_rate"] * 100, r["total"],
+            )
+
+        divisive_rows = select_divisive(cg_stats, min_findings_votes, top_n=3)
+        for r in divisive_rows:
+            log.info(
+                "Divisive: comment-id=%d (gap=%.0f pts, g0=%.0f%% n=%d, g1=%.0f%% n=%d)",
+                r["comment_id"],
+                r["agree_rate_gap"] * 100,
+                r["g0_agree_rate"] * 100, r["g0_voted"],
+                r["g1_agree_rate"] * 100, r["g1_voted"],
+            )
+
+        # Authoritative group sizes come from participant-votes.csv —
+        # the number of voters assigned to each group-id.
+        group_sizes: dict[int, int] = {}
+        if "group-id" in vote_matrix.columns:
+            for gid, count in vote_matrix["group-id"].dropna().astype(int).value_counts().items():
+                group_sizes[int(gid)] = int(count)
+
+        groups_rows = select_representative_per_group(
+            cg_stats, groups_count, per_group=3, group_sizes=group_sizes
+        )
+
         payload = {
+            "conversationClosed": True,
+            "consensus": [_consensus_card(r) for r in consensus_rows],
+            "divisive": [_divisive_card(r) for r in divisive_rows],
+            "groups": groups_rows,
             "stats": {
                 "votes": total_votes,
                 "statements": statements_count,
                 "participants": voters,
+                "votersInConv": voters_in_conv,
+                "commenters": commenters,
+                "groups": groups_count,
             },
-            "statements": cards,
+            "topStatements": top_cards,
         }
 
     payload = merge_lastupdated(payload)

--- a/src/site/_data/communityweekHighlights.json
+++ b/src/site/_data/communityweekHighlights.json
@@ -1,7 +1,216 @@
 {
-  "lastUpdated": "2026-05-14T23:53:54Z",
-  "statements": [
+  "consensus": [
     {
+      "isUserSubmitted": true,
+      "minGroupAgreeRate": 0.9,
+      "text": "A robust community enterprise means listening to people and adapting based on their needs.",
+      "votes": {
+        "agree": 92,
+        "disagree": 0,
+        "pass": 8,
+        "total": 13
+      }
+    },
+    {
+      "isUserSubmitted": false,
+      "minGroupAgreeRate": 0.8333,
+      "text": "There should be a \"community economy\" the way there is a creator economy, that is recognized and resourced",
+      "votes": {
+        "agree": 95,
+        "disagree": 0,
+        "pass": 5,
+        "total": 21
+      }
+    },
+    {
+      "isUserSubmitted": true,
+      "minGroupAgreeRate": 0.8,
+      "text": "Not a must but nice to have: impact measurement for their groups, data collection. This could also be beneficial for grant applications",
+      "votes": {
+        "agree": 80,
+        "disagree": 0,
+        "pass": 20,
+        "total": 20
+      }
+    },
+    {
+      "isUserSubmitted": false,
+      "minGroupAgreeRate": 0.6667,
+      "text": "Practical workshops from experienced community builders would help me more than written guides or general resources.",
+      "votes": {
+        "agree": 69,
+        "disagree": 5,
+        "pass": 26,
+        "total": 19
+      }
+    },
+    {
+      "isUserSubmitted": false,
+      "minGroupAgreeRate": 0.6429,
+      "text": "Subsidized access to venues across the five boroughs would change what I can do more than direct funding.",
+      "votes": {
+        "agree": 65,
+        "disagree": 15,
+        "pass": 20,
+        "total": 20
+      }
+    }
+  ],
+  "conversationClosed": true,
+  "divisive": [
+    {
+      "groupAgreeRates": [
+        {
+          "groupId": 0,
+          "n": 4,
+          "rate": 0.0
+        },
+        {
+          "groupId": 1,
+          "n": 13,
+          "rate": 0.9231
+        }
+      ],
+      "isUserSubmitted": true,
+      "text": "simple systems (like CRM/community platforms) so we can focus on the 'how'—rather than the administrative 'what.' and spaces to do it",
+      "votes": {
+        "agree": 71,
+        "disagree": 6,
+        "pass": 23,
+        "total": 17
+      }
+    },
+    {
+      "groupAgreeRates": [
+        {
+          "groupId": 0,
+          "n": 7,
+          "rate": 0.0
+        },
+        {
+          "groupId": 1,
+          "n": 16,
+          "rate": 0.8125
+        }
+      ],
+      "isUserSubmitted": false,
+      "text": "The platforms I rely on (Instagram, Eventbrite, Partiful) could change overnight and break my community",
+      "votes": {
+        "agree": 57,
+        "disagree": 13,
+        "pass": 30,
+        "total": 23
+      }
+    },
+    {
+      "groupAgreeRates": [
+        {
+          "groupId": 0,
+          "n": 7,
+          "rate": 0.1429
+        },
+        {
+          "groupId": 1,
+          "n": 13,
+          "rate": 0.9231
+        }
+      ],
+      "isUserSubmitted": false,
+      "text": "I would do this work full-time if I could financially.",
+      "votes": {
+        "agree": 65,
+        "disagree": 15,
+        "pass": 20,
+        "total": 20
+      }
+    }
+  ],
+  "groups": [
+    {
+      "id": 0,
+      "representativeStatements": [
+        {
+          "inGroupN": 7,
+          "inGroupRate": 0.4286,
+          "isUserSubmitted": false,
+          "outGroupN": 13,
+          "outGroupRate": 0.0,
+          "score": 6.462,
+          "text": "I would do this work full-time if I could financially.",
+          "voteType": "disagree"
+        },
+        {
+          "inGroupN": 7,
+          "inGroupRate": 0.2857,
+          "isUserSubmitted": false,
+          "outGroupN": 14,
+          "outGroupRate": 0.0,
+          "score": 4.8,
+          "text": "Venues that benefit from hosting communities should offer builders better terms (lower minimums, off-peak access, reduced fees) not just charge market rates.",
+          "voteType": "disagree"
+        },
+        {
+          "inGroupN": 7,
+          "inGroupRate": 0.2857,
+          "isUserSubmitted": false,
+          "outGroupN": 14,
+          "outGroupRate": 0.0,
+          "score": 4.8,
+          "text": "The city should treat community builders as a recognized category like artists or small businesses with permits, tax status, and access designed for them.",
+          "voteType": "disagree"
+        }
+      ],
+      "size": 8
+    },
+    {
+      "id": 1,
+      "representativeStatements": [
+        {
+          "inGroupN": 16,
+          "inGroupRate": 0.8125,
+          "isUserSubmitted": false,
+          "outGroupN": 7,
+          "outGroupRate": 0.0,
+          "score": 6.9966,
+          "text": "The platforms I rely on (Instagram, Eventbrite, Partiful) could change overnight and break my community",
+          "voteType": "agree"
+        },
+        {
+          "inGroupN": 13,
+          "inGroupRate": 0.6923,
+          "isUserSubmitted": false,
+          "outGroupN": 7,
+          "outGroupRate": 0.0,
+          "score": 5.9717,
+          "text": "The administrative side of community work (insurance, permits, legal, payments) is or would be a real barrier for me.",
+          "voteType": "agree"
+        },
+        {
+          "inGroupN": 13,
+          "inGroupRate": 0.9231,
+          "isUserSubmitted": true,
+          "outGroupN": 4,
+          "outGroupRate": 0.0,
+          "score": 5.1891,
+          "text": "simple systems (like CRM/community platforms) so we can focus on the 'how'—rather than the administrative 'what.' and spaces to do it",
+          "voteType": "agree"
+        }
+      ],
+      "size": 23
+    }
+  ],
+  "lastUpdated": "2026-05-15T03:24:59Z",
+  "stats": {
+    "commenters": 8,
+    "groups": 2,
+    "participants": 35,
+    "statements": 38,
+    "votersInConv": 31,
+    "votes": 770
+  },
+  "topStatements": [
+    {
+      "isUserSubmitted": false,
       "label": "Highest agreement",
       "text": "There should be a \"community economy\" the way there is a creator economy, that is recognized and resourced",
       "votes": {
@@ -12,6 +221,7 @@
       }
     },
     {
+      "isUserSubmitted": false,
       "label": "Most divided",
       "text": "The communities I build are partly a response to the failures of public institutions.",
       "votes": {
@@ -22,6 +232,7 @@
       }
     },
     {
+      "isUserSubmitted": false,
       "label": "Most engaged",
       "text": "I've thought seriously about stopping my community work in the past year because of burnout",
       "votes": {
@@ -31,10 +242,5 @@
         "total": 27
       }
     }
-  ],
-  "stats": {
-    "participants": 35,
-    "statements": 38,
-    "votes": 770
-  }
+  ]
 }

--- a/src/site/communityweeknyc/index.njk
+++ b/src/site/communityweeknyc/index.njk
@@ -142,9 +142,8 @@ closingBlurb: |
     >
       Join the conversation
     </h2>
-    <p class="mb-6 text-size-0 lg:text-size-1">
-      Vote on statements from other community builders, and add your own. It
-      takes 2 minutes.
+    <p class="inline-block mb-6 px-3 py-2 bg-light-gold border-2 border-black text-size--1 lg:text-size-0 font-bold uppercase tracking-wide">
+      Voting closed May 14. Results below.
     </p>
 
     <!--
@@ -213,38 +212,53 @@ closingBlurb: |
   </section>
 
   <!--
-    Running highlights — automatically populated from the live Polis
-    conversation. Do not edit by hand.
+    What emerged — post-conversation report, automatically populated
+    from the Polis CSV exports. Do not edit by hand.
 
     Data source: src/site/_data/communityweekHighlights.json
     Writer: scripts/update_cwnyc_highlights.py
-    Cron:   .github/workflows/update-cwnyc-highlights.yml (every 4h)
+    Workflow: .github/workflows/update-cwnyc-highlights.yml
+              (cron disabled; manual dispatch only after 2026-05-14)
 
-    The whole section hides if `statements` is empty, so the page ships
-    cleanly when the conversation hasn't crossed the safety thresholds yet
-    (see MIN_TOTAL_VOTES / MIN_PARTICIPANTS in the script).
+    The whole section hides if `topStatements` is empty. Each inner
+    subsection (consensus / divisive / groups) is independently
+    gated and degrades to absence when its array is empty.
 
     Schema:
       {
-        "lastUpdated": "2026-05-12T14:00:00Z",       // ISO timestamp, UTC
-        "stats": { "votes": N, "statements": N, "participants": N } | null,
-        "statements": [
-          {
-            "label": "Highest agreement"             // | "Most divided" | "Most engaged"
-                                                      //   — column header for the card
-            "text":  "The actual statement text from Polis.",
-            "votes": {
-              "agree":    78,                        // integer percentages,
-              "disagree":  8,                        //   sum to 100 via
-              "pass":     14,                        //   largest-remainder rounding
-              "total":   312                         // raw vote count (= agree+disagree+pass)
-            }
-          }
-          // up to 3
+        "lastUpdated":         "2026-05-14T20:00:00Z",
+        "conversationClosed":  true,
+        "stats": {
+          "votes": N, "statements": N, "participants": N,
+          "votersInConv": N, "commenters": N, "groups": N
+        } | null,
+        "topStatements": [ /* same three-card structure: label, text,
+                              isUserSubmitted, votes{agree,disagree,
+                              pass,total} */ ],
+        "consensus": [
+          { "text": "...", "isUserSubmitted": true|false,
+            "votes": {...}, "minGroupAgreeRate": 0.XX }
+        ],
+        "divisive": [
+          { "text": "...", "isUserSubmitted": true|false,
+            "votes": {...},
+            "groupAgreeRates": [
+              { "groupId": 0, "rate": 0.XX, "n": N },
+              { "groupId": 1, "rate": 0.YY, "n": N }
+            ] }
+        ],
+        "groups": [
+          { "id": 0, "size": N,
+            "representativeStatements": [
+              { "text": "...", "isUserSubmitted": true|false,
+                "voteType": "agree"|"disagree",
+                "inGroupRate": 0.XX, "outGroupRate": 0.YY,
+                "inGroupN": N, "outGroupN": N, "score": 0.ZZ }
+            ] }
         ]
       }
   -->
-  {% if communityweekHighlights and communityweekHighlights.statements and communityweekHighlights.statements.length %}
+  {% if communityweekHighlights and communityweekHighlights.topStatements and communityweekHighlights.topStatements.length %}
   <section
     id="highlights"
     class="col-span-columns mb-16 scroll-mt-8"
@@ -252,11 +266,15 @@ closingBlurb: |
     <h2
       class="font-display text-size-2 lg:text-size-4 uppercase mb-4"
     >
-      Running highlights
+      What emerged
     </h2>
     <p class="mb-8 text-size-0 lg:text-size-1">
-      A live snapshot of the conversation, refreshed automatically through
-      Community Week. Read it as a check-in, not a conclusion.
+      Community Week NYC ran from May 8–14, with
+      {% if communityweekHighlights.stats and communityweekHighlights.stats.participants %}{{ communityweekHighlights.stats.participants }}{% else %}dozens of{% endif %}
+      community builders contributing to this conversation. Below is a
+      summary of what emerged. The full conversation, including all
+      statements and the opinion-group visualization, is
+      <a class="inline-link" href="https://pol.is/6epckxncim" target="_blank" rel="noopener noreferrer">available on Polis</a>.
     </p>
 
     {% if communityweekHighlights.stats %}
@@ -276,13 +294,16 @@ closingBlurb: |
     </div>
     {% endif %}
 
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-12">
-      {% for s in communityweekHighlights.statements %}
+    <!-- Top three at-a-glance cards -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-16">
+      {% for s in communityweekHighlights.topStatements %}
       <article class="border-2 border-black p-6 flex flex-col bg-white">
         {% if s.label %}
         <p class="font-bold uppercase text-size--1 text-gray mb-3 tracking-wide">{{ s.label }}</p>
         {% endif %}
-        <p class="text-size-1 lg:text-size-2 mb-6 flex-grow">“{{ s.text }}”</p>
+        <p class="text-size-1 lg:text-size-2 mb-6 flex-grow">“{{ s.text }}”
+          {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
+        </p>
         <div class="flex h-2 mb-2 overflow-hidden" aria-hidden="true">
           <span class="block bg-black" style="width: {{ s.votes.agree }}%"></span>
           <span class="block bg-red" style="width: {{ s.votes.disagree }}%"></span>
@@ -294,6 +315,111 @@ closingBlurb: |
       </article>
       {% endfor %}
     </div>
+
+    <!-- Points of consensus -->
+    {% if communityweekHighlights.consensus and communityweekHighlights.consensus.length %}
+    <div class="mb-16">
+      <h3 class="font-display text-size-2 lg:text-size-2 uppercase mb-6">
+        Points of consensus
+      </h3>
+      <ol class="space-y-6">
+        {% for s in communityweekHighlights.consensus %}
+        <li class="border-b border-black pb-6 last:border-b-0">
+          <p class="text-size-0 lg:text-size-1 mb-3">“{{ s.text }}”
+            {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
+          </p>
+          <div class="flex h-2 mb-2 overflow-hidden" aria-hidden="true">
+            <span class="block bg-black" style="width: {{ s.votes.agree }}%"></span>
+            <span class="block bg-red" style="width: {{ s.votes.disagree }}%"></span>
+            <span class="block bg-gray" style="width: {{ s.votes.pass }}%"></span>
+          </div>
+          <p class="text-size--4 text-gray">
+            {{ s.votes.agree }}% agree · {{ s.votes.disagree }}% disagree · {{ s.votes.pass }}% pass · {{ s.votes.total }} votes
+            · agreed across both opinion groups (lowest group agree rate: {{ (s.minGroupAgreeRate * 100) | round | int }}%)
+          </p>
+        </li>
+        {% endfor %}
+      </ol>
+    </div>
+    {% endif %}
+
+    <!-- Where the cohort divided -->
+    {% if communityweekHighlights.divisive and communityweekHighlights.divisive.length %}
+    <div class="mb-16">
+      <h3 class="font-display text-size-2 lg:text-size-2 uppercase mb-6">
+        Where the cohort divided
+      </h3>
+      <ol class="space-y-8">
+        {% for s in communityweekHighlights.divisive %}
+        <li class="border-b border-black pb-8 last:border-b-0">
+          <p class="text-size-0 lg:text-size-1 mb-4">“{{ s.text }}”
+            {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
+          </p>
+          <div class="flex h-2 mb-2 overflow-hidden" aria-hidden="true">
+            <span class="block bg-black" style="width: {{ s.votes.agree }}%"></span>
+            <span class="block bg-red" style="width: {{ s.votes.disagree }}%"></span>
+            <span class="block bg-gray" style="width: {{ s.votes.pass }}%"></span>
+          </div>
+          <p class="text-size--4 text-gray mb-4">
+            Overall: {{ s.votes.agree }}% agree · {{ s.votes.disagree }}% disagree · {{ s.votes.pass }}% pass · {{ s.votes.total }} votes
+          </p>
+          <div class="space-y-2">
+            {% for g in s.groupAgreeRates %}
+            <div>
+              <div class="flex items-baseline justify-between mb-1">
+                <span class="text-size--2 lg:text-size--1 font-bold uppercase tracking-wide">Group {{ g.groupId + 1 }}</span>
+                <span class="text-size--4 text-gray">{{ (g.rate * 100) | round | int }}% agree · n={{ g.n }}</span>
+              </div>
+              <div class="flex h-2 bg-light-gold overflow-hidden border border-black" aria-hidden="true">
+                <span class="block bg-black" style="width: {{ (g.rate * 100) | round | int }}%"></span>
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+        </li>
+        {% endfor %}
+      </ol>
+    </div>
+    {% endif %}
+
+    <!-- Opinion groups -->
+    {% if communityweekHighlights.groups and communityweekHighlights.groups.length %}
+    <div class="mb-16">
+      <h3 class="font-display text-size-2 lg:text-size-2 uppercase mb-4">
+        Opinion groups
+      </h3>
+      <p class="mb-8 text-size-0">
+        Polis identified two distinct opinion groups in the conversation.
+        Each is characterized below by the statements its members were
+        most distinctively likely to agree or disagree with.
+      </p>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {% for g in communityweekHighlights.groups %}
+        <div class="border-2 border-black p-6 bg-white">
+          <p class="font-bold uppercase text-size-0 mb-1 tracking-wide">Group {{ g.id + 1 }}</p>
+          <p class="text-size--2 text-gray mb-6">{{ g.size }} participant{% if g.size != 1 %}s{% endif %}</p>
+          <ol class="space-y-5">
+            {% for s in g.representativeStatements %}
+            <li>
+              <p class="font-bold uppercase text-size--2 text-gray mb-2 tracking-wide">
+                Most distinctively {{ s.voteType }}D with
+              </p>
+              <p class="text-size--1 lg:text-size-0 mb-2">“{{ s.text }}”
+                {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
+              </p>
+              <p class="text-size--4 text-gray">
+                {{ (s.inGroupRate * 100) | round | int }}% of this group {{ s.voteType }}d
+                (n={{ s.inGroupN }}), vs {{ (s.outGroupRate * 100) | round | int }}% of others
+                (n={{ s.outGroupN }})
+              </p>
+            </li>
+            {% endfor %}
+          </ol>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
 
     {% if communityweekHighlights.lastUpdated %}
     <p class="text-size--4 text-gray">


### PR DESCRIPTION
Converts the hourly-snapshot highlights section into a post-conversation summary for tomorrow morning's *Future of Social Connection* event. Conversation `6epckxncim` closed 2026-05-14.

## What's new on the page

- **Voting-closed banner** above the Polis embed (replaces the "Vote… takes 2 minutes" subtitle).
- **Section reframed**: "Running highlights" → **"What emerged"**, with a closing-week framing line.
- **Top three at-a-glance cards** retained (highest agreement / most divided / most engaged), with a new "submitted by a participant" tag inline.
- **Points of consensus** — top 5 by minimum-across-groups agree rate.
- **Where the cohort divided** — top 3 by absolute agree-rate gap between groups, with per-group bars.
- **Opinion groups** — one card per group with 2–3 representative statements labeled *Most distinctively AGREED with* / *DISAGREED with*.

## Algorithm (per spec)

- **Representative comments**: Polis's documented formula. Laplace-smoothed `P_v(g, c) = (N_a_v + 1) / (N_v + 2)`, ratio `R = P_in / P_out`, Fisher's exact two-tailed for `p`, combined `score = R * (1 - p)`. Per group: rank by score desc, take top 3 distinct statements across both vote types.
- **Noise filter**: candidate dropped if in-group voters < 4 on that statement.
- **Consensus**: top 5 by `min(g0_agree_rate, g1_agree_rate)` among statements with `total >= max(5, ceil(0.25 * voters_in_conv)) = 8`.
- **Divisive**: top 3 by `|g0_agree_rate − g1_agree_rate|` over the same eligible set.
- **scipy** added to deps for `fisher_exact`. **Cron disabled**; manual `workflow_dispatch` only after the conversation closed.

## Pre-flight observations (worth knowing before merge)

This is what the live data actually produced. I cross-referenced the top divisive statement (comment 44, user-submitted) by hand: 0/4 group 0 agreed, 12/13 group 1 agreed, 92pp gap — matches JSON exactly. Algorithm is operating correctly.

**Asymmetric groups (8 vs 23)**. Polis split the 31 voters_in_conv into a small Group 1 (8 members) and a large Group 2 (23). Group 1's representative statements are statistically weaker as a result:
- Top rep for Group 1: 3 of 7 disagreed vs 0 of 13 — solid signal (Fisher p=0.03)
- Reps #2 and #3 for Group 1: 2 of 7 disagreed each (29% vs 0%). Fisher p=0.10 — below conventional significance. They clear the noise filter (`N_v=7 > 4`) but are driven by just 2 voters each. Honest framing in the rendered output: "29% of this group disagreed (n=7), vs 0% of others (n=14)."

**Consensus #4 and #5 are weaker than the top three:**
- #4: 69% agree, 5% disagree, **26% pass** (lowest group rate: 67%)
- #5: 65% agree, 15% disagree, 20% pass (lowest group rate: 64%)

The top three consensus rows are strong (90%, 83%, 80% min-group-agree). The bottom two are "more people agreed than disagreed, but lots passed." 64% nudges the spec's "60% isn't consensus" warning line.

**Top divisive is driven by small Group 1 sample.** Comment 44 has 0/4 group 1 voters agreeing. Real disagreement direction, but the 0% is brittle — a single dissent would have made it 25%.

**Comment count correction.** The brief said "22 user-submitted statements out of 51." Actual: 9 user-submitted (8 visible after moderation, 1 removed). 42 seed statements (30 visible). The `isUserSubmitted` flag and tag display are correctly limited to the 8 visible user-submitted comments.

**My take**: data supports the report. Group 2's three reps are clean and statistically significant. Consensus #1–#3 and divisive #2–#3 are strong. The flagged weak items are real but modest — the rendered output communicates uncertainty honestly (showing `n=X` everywhere). Not blocking; surfacing for your call on whether to trim consensus to 3 strong ones.

## Verified

- ✅ All **29 unit tests pass** locally (existing logic + new Fisher / rep-ratio / consensus / divisive / noise-filter / groups==1 edge / isUserSubmitted).
- ✅ Fisher exact wrapper matches `scipy.stats.fisher_exact` on four reference 2×2 tables.
- ✅ Manual cross-reference of top divisive (comment 44) against `comment-groups.csv` raw counts: identical.
- ✅ Dry-run against live data: 770 votes / 31 voters_in_conv / 35 voters / 8+23 group split / 38 visible statements.
- ✅ Built site: all four subsection headings present in dist HTML, voting-closed banner present, per-statement percentage rendering correct via `(rate * 100) | round | int`.
- ✅ Group sizes correct in output (8 and 23, sourced from participant-votes.csv group-id counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)