### PR TITLE
CWNYC: retune highlights as mid-conversation snapshot (voting still open)

### DIFF
--- a/.github/workflows/update-cwnyc-highlights.yml
+++ b/.github/workflows/update-cwnyc-highlights.yml
@@ -3,19 +3,18 @@
 # Netlify rebuilds on the resulting commit, so the page reflects the
 # latest snapshot within ~minutes of each run.
 #
-# Conversation closed 2026-05-14. Cron disabled — `workflow_dispatch`
-# only. Re-enable by uncommenting the schedule block below if the
-# conversation reopens (and bump the cron expression appropriately).
+# Hourly refresh during Community Week event (May 15). Disable by
+# commenting out the schedule block once the conversation is fully
+# closed.
 #
 # GitHub will email the workflow author on workflow failures by
-# default, so transient pol.is outages on manual runs surface without
-# extra config.
+# default, so transient pol.is outages surface without extra config.
 
 name: Update CWNYC highlights
 
 on:
-  # schedule:
-  #   - cron: "0 * * * *"  # hourly on the hour, UTC — disabled 2026-05-14
+  schedule:
+    - cron: "0 * * * *"  # hourly on the hour, UTC
   workflow_dispatch: {}
 
 # Avoid overlapping runs if a scheduled run is still going when the

--- a/scripts/test_update_cwnyc_highlights.py
+++ b/scripts/test_update_cwnyc_highlights.py
@@ -288,10 +288,10 @@ class SelectRepresentativePerGroupTests(unittest.TestCase):
         self.assertIn(("comment-1", "agree"), g1_votes)
 
 
-# ---- Consensus / divisive ------------------------------------------------
+# ---- Consensus ----------------------------------------------------------
 
 
-class ConsensusDivisiveTests(unittest.TestCase):
+class ConsensusTests(unittest.TestCase):
     def test_consensus_picks_minimum_across_groups(self):
         # Comment 0: both groups strongly agree -> consensus
         # Comment 1: group 0 agrees, group 1 doesn't -> not consensus
@@ -330,51 +330,6 @@ class ConsensusDivisiveTests(unittest.TestCase):
         ]
         self.assertEqual(uch.select_consensus(stats, min_votes=10), [])
 
-    def test_divisive_picks_largest_gap(self):
-        # Three comments:
-        # 0: g0 92% agree, g1 10% agree -> gap 82pp (highest)
-        # 1: g0 50% agree, g1 30% agree -> gap 20pp
-        # 2: g0 25% agree, g1 25% agree -> gap 0pp (consensus, not divisive)
-        stats = [
-            _cg_stat(
-                0,
-                g0_voted=12, g0_agree=11, g0_disagree=0, g0_pass=1,
-                g1_voted=20, g1_agree=2, g1_disagree=16, g1_pass=2,
-            ),
-            _cg_stat(
-                1,
-                g0_voted=10, g0_agree=5, g0_disagree=2, g0_pass=3,
-                g1_voted=10, g1_agree=3, g1_disagree=4, g1_pass=3,
-            ),
-            _cg_stat(
-                2,
-                g0_voted=8, g0_agree=2, g0_disagree=4, g0_pass=2,
-                g1_voted=8, g1_agree=2, g1_disagree=4, g1_pass=2,
-            ),
-        ]
-        divisive = uch.select_divisive(stats, min_votes=5, top_n=3)
-        self.assertEqual(len(divisive), 3)
-        self.assertEqual(divisive[0]["comment_id"], 0)
-
-    def test_divisive_skips_comments_with_empty_group(self):
-        # Comment 0 has zero group-0 voters -> gap is undefined -> dropped.
-        # Comment 1 has both groups -> included.
-        stats = [
-            _cg_stat(
-                0,
-                g0_voted=0, g0_agree=0, g0_disagree=0, g0_pass=0,
-                g1_voted=10, g1_agree=10, g1_disagree=0, g1_pass=0,
-            ),
-            _cg_stat(
-                1,
-                g0_voted=6, g0_agree=5, g0_disagree=0, g0_pass=1,
-                g1_voted=6, g1_agree=0, g1_disagree=5, g1_pass=1,
-            ),
-        ]
-        divisive = uch.select_divisive(stats, min_votes=5)
-        self.assertEqual(len(divisive), 1)
-        self.assertEqual(divisive[0]["comment_id"], 1)
-
 
 # ---- Output shape: isUserSubmitted propagates --------------------------
 
@@ -393,20 +348,6 @@ class IsUserSubmittedPropagationTests(unittest.TestCase):
         cards = [uch._consensus_card(r) for r in consensus]
         self.assertEqual(len(cards), 1)
         self.assertTrue(cards[0]["isUserSubmitted"])
-
-    def test_divisive_card_carries_flag(self):
-        stats = [
-            _cg_stat(
-                0,
-                g0_voted=8, g0_agree=7, g0_disagree=0, g0_pass=1,
-                g1_voted=20, g1_agree=2, g1_disagree=16, g1_pass=2,
-                is_user=False,
-            ),
-        ]
-        divisive = uch.select_divisive(stats, min_votes=5)
-        cards = [uch._divisive_card(r) for r in divisive]
-        self.assertEqual(len(cards), 1)
-        self.assertFalse(cards[0]["isUserSubmitted"])
 
 
 if __name__ == "__main__":

--- a/scripts/update_cwnyc_highlights.py
+++ b/scripts/update_cwnyc_highlights.py
@@ -5,15 +5,12 @@ Pulls public CSV exports for conversation 6epckxncim / report
 r45wsbrxmtk78wndwbhpm and writes the JSON file that
 src/site/communityweeknyc/index.njk reads.
 
-The conversation closed on 2026-05-14. This script now produces a
-post-conversation report including:
+This script produces a mid-conversation snapshot including:
 
-- `topStatements`: the original three at-a-glance cards (highest
-  agreement / most divided / most engaged)
+- `topStatements`: three at-a-glance cards (highest agreement /
+  most divided / most engaged)
 - `consensus`: top 5 statements with the highest minimum-across-groups
   agree rate (i.e. agreed-on by both opinion groups)
-- `divisive`: top 3 statements with the largest agree-rate gap between
-  the two opinion groups
 - `groups`: per-group representative statements computed using Polis's
   documented representative-comments algorithm
   (https://compdemocracy.org/representative-comments/) — Laplace-
@@ -62,11 +59,11 @@ MIN_PARTICIPANTS = 0
 MIN_VOTES_PER_STATEMENT_FLOOR = 5
 MIN_VOTES_PER_STATEMENT_RATIO = 0.3
 
-# Min-votes threshold for consensus/divisive selection. Uses
-# `voters_in_conv` (the population Polis itself uses for analysis —
-# people who voted on enough comments to be assigned a group), not
-# `voters`. ceil() so that "25% of voters_in_conv" rounds up — at 31
-# voters_in_conv this gives 8.
+# Min-votes threshold for consensus selection. Uses `voters_in_conv`
+# (the population Polis itself uses for analysis — people who voted on
+# enough comments to be assigned a group), not `voters`. ceil() so
+# that "25% of voters_in_conv" rounds up — at 31 voters_in_conv this
+# gives 8.
 def min_votes_for_findings(voters_in_conv: int) -> int:
     return max(5, math.ceil(0.25 * voters_in_conv))
 
@@ -341,7 +338,7 @@ def representative_score(
     return r, p, r * (1 - p)
 
 
-# ---- Consensus / divisive / per-group selection ---------------------------
+# ---- Consensus / per-group selection --------------------------------------
 
 
 def select_consensus(
@@ -369,35 +366,6 @@ def select_consensus(
             }
         )
     enriched.sort(key=lambda r: (-r["min_group_agree_rate"], -r["total"]))
-    return enriched[:top_n]
-
-
-def select_divisive(
-    cg_stats: list[dict[str, Any]],
-    min_votes: int,
-    top_n: int = 3,
-) -> list[dict[str, Any]]:
-    """Statements with the largest absolute gap in agree rate between
-    groups. Both groups must have at least one voter on the comment
-    (otherwise the gap is meaningless)."""
-    candidates = [
-        r
-        for r in cg_stats
-        if r["total"] >= min_votes and r["g0_voted"] > 0 and r["g1_voted"] > 0
-    ]
-    enriched = []
-    for r in candidates:
-        g0_rate = r["g0_agree"] / r["g0_voted"]
-        g1_rate = r["g1_agree"] / r["g1_voted"]
-        enriched.append(
-            {
-                **r,
-                "g0_agree_rate": g0_rate,
-                "g1_agree_rate": g1_rate,
-                "agree_rate_gap": abs(g0_rate - g1_rate),
-            }
-        )
-    enriched.sort(key=lambda r: (-r["agree_rate_gap"], -r["total"]))
     return enriched[:top_n]
 
 
@@ -580,26 +548,6 @@ def _consensus_card(r: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _divisive_card(r: dict[str, Any]) -> dict[str, Any]:
-    pct_a, pct_d, pct_p = percentages_to_100(
-        [r["total_agree"], r["total_disagree"], r["total_pass"]]
-    )
-    return {
-        "text": r["text"],
-        "isUserSubmitted": r["isUserSubmitted"],
-        "votes": {
-            "agree": pct_a,
-            "disagree": pct_d,
-            "pass": pct_p,
-            "total": r["total"],
-        },
-        "groupAgreeRates": [
-            {"groupId": 0, "rate": round(r["g0_agree_rate"], 4), "n": r["g0_voted"]},
-            {"groupId": 1, "rate": round(r["g1_agree_rate"], 4), "n": r["g1_voted"]},
-        ],
-    }
-
-
 # ---- Main ------------------------------------------------------------------
 
 
@@ -634,9 +582,7 @@ def main() -> int:
     if total_votes < MIN_TOTAL_VOTES or voters < MIN_PARTICIPANTS:
         log.info("Below safety gate. Writing empty state.")
         payload: dict[str, Any] = {
-            "conversationClosed": True,
             "consensus": [],
-            "divisive": [],
             "groups": [],
             "stats": None,
             "topStatements": [],
@@ -651,7 +597,7 @@ def main() -> int:
         cg_stats = parse_comment_groups(comments, comment_groups)
         min_findings_votes = min_votes_for_findings(voters_in_conv)
         log.info(
-            "Consensus/divisive eligibility: votes>=%d (max(5, ceil(0.25*%d)))",
+            "Consensus eligibility: votes>=%d (max(5, ceil(0.25*%d)))",
             min_findings_votes, voters_in_conv,
         )
 
@@ -660,16 +606,6 @@ def main() -> int:
             log.info(
                 "Consensus: comment-id=%d (min group agree=%.0f%%, total=%d)",
                 r["comment_id"], r["min_group_agree_rate"] * 100, r["total"],
-            )
-
-        divisive_rows = select_divisive(cg_stats, min_findings_votes, top_n=3)
-        for r in divisive_rows:
-            log.info(
-                "Divisive: comment-id=%d (gap=%.0f pts, g0=%.0f%% n=%d, g1=%.0f%% n=%d)",
-                r["comment_id"],
-                r["agree_rate_gap"] * 100,
-                r["g0_agree_rate"] * 100, r["g0_voted"],
-                r["g1_agree_rate"] * 100, r["g1_voted"],
             )
 
         # Authoritative group sizes come from participant-votes.csv —
@@ -684,9 +620,7 @@ def main() -> int:
         )
 
         payload = {
-            "conversationClosed": True,
             "consensus": [_consensus_card(r) for r in consensus_rows],
-            "divisive": [_divisive_card(r) for r in divisive_rows],
             "groups": groups_rows,
             "stats": {
                 "votes": total_votes,

--- a/src/site/_data/communityweekHighlights.json
+++ b/src/site/_data/communityweekHighlights.json
@@ -56,75 +56,6 @@
       }
     }
   ],
-  "conversationClosed": true,
-  "divisive": [
-    {
-      "groupAgreeRates": [
-        {
-          "groupId": 0,
-          "n": 4,
-          "rate": 0.0
-        },
-        {
-          "groupId": 1,
-          "n": 13,
-          "rate": 0.9231
-        }
-      ],
-      "isUserSubmitted": true,
-      "text": "simple systems (like CRM/community platforms) so we can focus on the 'how'—rather than the administrative 'what.' and spaces to do it",
-      "votes": {
-        "agree": 71,
-        "disagree": 6,
-        "pass": 23,
-        "total": 17
-      }
-    },
-    {
-      "groupAgreeRates": [
-        {
-          "groupId": 0,
-          "n": 7,
-          "rate": 0.0
-        },
-        {
-          "groupId": 1,
-          "n": 16,
-          "rate": 0.8125
-        }
-      ],
-      "isUserSubmitted": false,
-      "text": "The platforms I rely on (Instagram, Eventbrite, Partiful) could change overnight and break my community",
-      "votes": {
-        "agree": 57,
-        "disagree": 13,
-        "pass": 30,
-        "total": 23
-      }
-    },
-    {
-      "groupAgreeRates": [
-        {
-          "groupId": 0,
-          "n": 7,
-          "rate": 0.1429
-        },
-        {
-          "groupId": 1,
-          "n": 13,
-          "rate": 0.9231
-        }
-      ],
-      "isUserSubmitted": false,
-      "text": "I would do this work full-time if I could financially.",
-      "votes": {
-        "agree": 65,
-        "disagree": 15,
-        "pass": 20,
-        "total": 20
-      }
-    }
-  ],
   "groups": [
     {
       "id": 0,
@@ -199,7 +130,7 @@
       "size": 23
     }
   ],
-  "lastUpdated": "2026-05-15T03:24:59Z",
+  "lastUpdated": "2026-05-15T03:47:16Z",
   "stats": {
     "commenters": 8,
     "groups": 2,

--- a/src/site/communityweeknyc/index.njk
+++ b/src/site/communityweeknyc/index.njk
@@ -132,7 +132,200 @@ closingBlurb: |
     </div>
   </section>
 
-  <!-- Polis embed -->
+  <!--
+    What's emerging — mid-conversation snapshot, automatically populated
+    from the Polis CSV exports on an hourly cron. Do not edit by hand.
+
+    Data source: src/site/_data/communityweekHighlights.json
+    Writer: scripts/update_cwnyc_highlights.py
+    Workflow: .github/workflows/update-cwnyc-highlights.yml (hourly cron)
+
+    The whole section hides if `topStatements` is empty. Each inner
+    subsection (consensus / groups) is independently gated and degrades
+    to absence when its array is empty.
+
+    Schema:
+      {
+        "lastUpdated":   "2026-05-15T07:00:00Z",
+        "stats": {
+          "votes": N, "statements": N, "participants": N,
+          "votersInConv": N, "commenters": N, "groups": N
+        } | null,
+        "topStatements": [ /* three at-a-glance cards: label, text,
+                              isUserSubmitted, votes{agree,disagree,
+                              pass,total} */ ],
+        "consensus": [
+          { "text": "...", "isUserSubmitted": true|false,
+            "votes": {...}, "minGroupAgreeRate": 0.XX }
+        ],
+        "groups": [
+          { "id": 0, "size": N,
+            "representativeStatements": [
+              { "text": "...", "isUserSubmitted": true|false,
+                "voteType": "agree"|"disagree",
+                "inGroupRate": 0.XX, "outGroupRate": 0.YY,
+                "inGroupN": N, "outGroupN": N, "score": 0.ZZ }
+            ] }
+        ]
+      }
+  -->
+  {% if communityweekHighlights and communityweekHighlights.topStatements and communityweekHighlights.topStatements.length %}
+  <section
+    id="highlights"
+    class="col-span-columns mb-16 scroll-mt-8"
+  >
+    <h2
+      class="font-display text-size-2 lg:text-size-4 uppercase mb-4"
+    >
+      What's emerging
+    </h2>
+    <p class="mb-8 text-size-0 lg:text-size-1">
+      Community Week NYC is running through May 15, with
+      {% if communityweekHighlights.stats and communityweekHighlights.stats.participants %}{{ communityweekHighlights.stats.participants }}{% else %}dozens of{% endif %}
+      community builders contributing to this conversation so far. Below
+      is a snapshot of what's emerging. Voting is still open — results
+      will continue to shift as more people vote.
+    </p>
+
+    {% if communityweekHighlights.stats %}
+    <div class="grid grid-cols-3 border-y-2 border-black mb-8">
+      <div class="py-4 lg:py-6 px-2 text-center border-r-2 border-black">
+        <p class="font-display text-size-2 lg:text-size-4 leading-none">{{ communityweekHighlights.stats.votes }}</p>
+        <p class="text-size--2 lg:text-size--1 uppercase mt-2">Votes</p>
+      </div>
+      <div class="py-4 lg:py-6 px-2 text-center border-r-2 border-black">
+        <p class="font-display text-size-2 lg:text-size-4 leading-none">{{ communityweekHighlights.stats.statements }}</p>
+        <p class="text-size--2 lg:text-size--1 uppercase mt-2">Statements</p>
+      </div>
+      <div class="py-4 lg:py-6 px-2 text-center">
+        <p class="font-display text-size-2 lg:text-size-4 leading-none">{{ communityweekHighlights.stats.participants }}</p>
+        <p class="text-size--2 lg:text-size--1 uppercase mt-2">Participants</p>
+      </div>
+    </div>
+    {% endif %}
+
+    <p class="mb-12 text-size--1 lg:text-size-0 text-gray">
+      Polis groups participants by how similarly they vote. Below are the
+      patterns that have emerged so far — statements both groups agreed
+      on, and what distinguishes the two clusters of voters from each
+      other.
+    </p>
+
+    <!-- Top three at-a-glance cards -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-16">
+      {% for s in communityweekHighlights.topStatements %}
+      <article class="border-2 border-black p-6 flex flex-col bg-white">
+        {% if s.label %}
+        <p class="font-bold uppercase text-size--1 text-gray mb-3 tracking-wide">{{ s.label }}</p>
+        {% endif %}
+        <p class="text-size-1 lg:text-size-2 mb-6 flex-grow">“{{ s.text }}”
+          {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
+        </p>
+        <div class="flex h-2 mb-2 overflow-hidden" aria-hidden="true">
+          <span class="block bg-black" style="width: {{ s.votes.agree }}%"></span>
+          <span class="block bg-red" style="width: {{ s.votes.disagree }}%"></span>
+          <span class="block bg-gray" style="width: {{ s.votes.pass }}%"></span>
+        </div>
+        <p class="text-size--4 text-gray">
+          {{ s.votes.agree }}% agree · {{ s.votes.disagree }}% disagree · {{ s.votes.pass }}% pass · {{ s.votes.total }} votes
+        </p>
+      </article>
+      {% endfor %}
+    </div>
+
+    <!-- Points of consensus -->
+    {% if communityweekHighlights.consensus and communityweekHighlights.consensus.length %}
+    <div class="mb-16">
+      <h3 class="font-display text-size-2 lg:text-size-2 uppercase mb-2">
+        Points of consensus
+      </h3>
+      <p class="italic text-size--1 text-gray mb-6">
+        Statements both opinion groups agreed on most strongly.
+      </p>
+      <ol class="space-y-6">
+        {% for s in communityweekHighlights.consensus %}
+        <li class="border-b border-black pb-6 last:border-b-0">
+          <p class="text-size-0 lg:text-size-1 mb-3">“{{ s.text }}”
+            {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
+          </p>
+          <div class="flex h-2 mb-2 overflow-hidden" aria-hidden="true">
+            <span class="block bg-black" style="width: {{ s.votes.agree }}%"></span>
+            <span class="block bg-red" style="width: {{ s.votes.disagree }}%"></span>
+            <span class="block bg-gray" style="width: {{ s.votes.pass }}%"></span>
+          </div>
+          <p class="text-size--4 text-gray">
+            {{ s.votes.agree }}% agree · {{ s.votes.disagree }}% disagree · {{ s.votes.pass }}% pass · {{ s.votes.total }} votes
+            · agreed across both opinion groups (lowest group agree rate: {{ (s.minGroupAgreeRate * 100) | round | int }}%)
+          </p>
+        </li>
+        {% endfor %}
+      </ol>
+    </div>
+    {% endif %}
+
+    <!-- Opinion groups -->
+    {% if communityweekHighlights.groups and communityweekHighlights.groups.length %}
+    <div class="mb-16">
+      <h3 class="font-display text-size-2 lg:text-size-2 uppercase mb-4">
+        Opinion groups
+      </h3>
+      <p class="mb-8 text-size-0">
+        Polis identified two clusters of voters based on patterns in how
+        they voted. Each group is characterized below by the statements
+        that set them apart from the other group — what was statistically
+        distinctive about their voting, not what every group member voted.
+      </p>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        {% for g in communityweekHighlights.groups %}
+        <div class="border-2 border-black p-6 bg-white">
+          <p class="font-bold uppercase text-size-0 mb-1 tracking-wide">Group {{ g.id + 1 }}</p>
+          <p class="text-size--2 text-gray mb-6">{{ g.size }} participant{% if g.size != 1 %}s{% endif %}</p>
+          <ol class="space-y-5">
+            {% for s in g.representativeStatements %}
+            <li>
+              <p class="font-bold uppercase text-size--2 text-gray mb-2 tracking-wide">
+                Most distinctively {{ s.voteType }}D with
+              </p>
+              <p class="text-size--1 lg:text-size-0 mb-2">“{{ s.text }}”
+                {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
+              </p>
+              <p class="text-size--4 text-gray">
+                {{ (s.inGroupRate * 100) | round | int }}% of this group {{ s.voteType }}d
+                (n={{ s.inGroupN }}), vs {{ (s.outGroupRate * 100) | round | int }}% of others
+                (n={{ s.outGroupN }})
+              </p>
+            </li>
+            {% endfor %}
+          </ol>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+
+    {% if communityweekHighlights.stats and communityweekHighlights.stats.participants %}
+    <p class="italic text-size--1 text-gray mb-4">
+      This is a small sample ({{ communityweekHighlights.stats.participants }} voters,
+      {% if communityweekHighlights.stats.groups %}{{ communityweekHighlights.stats.groups }}{% else %}2{% endif %} groups).
+      Findings are suggestive of patterns in the conversation, not
+      definitive about NYC community builders as a whole. The full
+      conversation is
+      <a class="inline-link" href="https://pol.is/6epckxncim" target="_blank" rel="noopener noreferrer">available on Polis</a>.
+    </p>
+    {% endif %}
+
+    {% if communityweekHighlights.lastUpdated %}
+    <p class="text-size--4 text-gray">
+      Last updated: {{ communityweekHighlights.lastUpdated | readableDate }}.
+      Conversation data via
+      <a href="https://pol.is" class="inline-link" target="_blank" rel="noopener noreferrer">Polis</a>,
+      <a href="https://creativecommons.org/licenses/by/4.0/" class="inline-link" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>.
+    </p>
+    {% endif %}
+  </section>
+  {% endif %}
+
+  <!-- Polis embed (moved below results — invites voting on top of in-progress data) -->
   <section
     id="join"
     class="col-span-columns mb-16 scroll-mt-8"
@@ -140,10 +333,11 @@ closingBlurb: |
     <h2
       class="font-display text-size-2 lg:text-size-4 uppercase mb-4"
     >
-      Join the conversation
+      Add your voice
     </h2>
-    <p class="inline-block mb-6 px-3 py-2 bg-light-gold border-2 border-black text-size--1 lg:text-size-0 font-bold uppercase tracking-wide">
-      Voting closed May 14. Results below.
+    <p class="mb-6 text-size-0 lg:text-size-1">
+      Voting is still open. Take 2 minutes to vote on statements — or
+      submit your own — and your input will appear in the results above.
     </p>
 
     <!--
@@ -210,227 +404,6 @@ closingBlurb: |
       </a>
     </p>
   </section>
-
-  <!--
-    What emerged — post-conversation report, automatically populated
-    from the Polis CSV exports. Do not edit by hand.
-
-    Data source: src/site/_data/communityweekHighlights.json
-    Writer: scripts/update_cwnyc_highlights.py
-    Workflow: .github/workflows/update-cwnyc-highlights.yml
-              (cron disabled; manual dispatch only after 2026-05-14)
-
-    The whole section hides if `topStatements` is empty. Each inner
-    subsection (consensus / divisive / groups) is independently
-    gated and degrades to absence when its array is empty.
-
-    Schema:
-      {
-        "lastUpdated":         "2026-05-14T20:00:00Z",
-        "conversationClosed":  true,
-        "stats": {
-          "votes": N, "statements": N, "participants": N,
-          "votersInConv": N, "commenters": N, "groups": N
-        } | null,
-        "topStatements": [ /* same three-card structure: label, text,
-                              isUserSubmitted, votes{agree,disagree,
-                              pass,total} */ ],
-        "consensus": [
-          { "text": "...", "isUserSubmitted": true|false,
-            "votes": {...}, "minGroupAgreeRate": 0.XX }
-        ],
-        "divisive": [
-          { "text": "...", "isUserSubmitted": true|false,
-            "votes": {...},
-            "groupAgreeRates": [
-              { "groupId": 0, "rate": 0.XX, "n": N },
-              { "groupId": 1, "rate": 0.YY, "n": N }
-            ] }
-        ],
-        "groups": [
-          { "id": 0, "size": N,
-            "representativeStatements": [
-              { "text": "...", "isUserSubmitted": true|false,
-                "voteType": "agree"|"disagree",
-                "inGroupRate": 0.XX, "outGroupRate": 0.YY,
-                "inGroupN": N, "outGroupN": N, "score": 0.ZZ }
-            ] }
-        ]
-      }
-  -->
-  {% if communityweekHighlights and communityweekHighlights.topStatements and communityweekHighlights.topStatements.length %}
-  <section
-    id="highlights"
-    class="col-span-columns mb-16 scroll-mt-8"
-  >
-    <h2
-      class="font-display text-size-2 lg:text-size-4 uppercase mb-4"
-    >
-      What emerged
-    </h2>
-    <p class="mb-8 text-size-0 lg:text-size-1">
-      Community Week NYC ran from May 8–14, with
-      {% if communityweekHighlights.stats and communityweekHighlights.stats.participants %}{{ communityweekHighlights.stats.participants }}{% else %}dozens of{% endif %}
-      community builders contributing to this conversation. Below is a
-      summary of what emerged. The full conversation, including all
-      statements and the opinion-group visualization, is
-      <a class="inline-link" href="https://pol.is/6epckxncim" target="_blank" rel="noopener noreferrer">available on Polis</a>.
-    </p>
-
-    {% if communityweekHighlights.stats %}
-    <div class="grid grid-cols-3 border-y-2 border-black mb-12">
-      <div class="py-4 lg:py-6 px-2 text-center border-r-2 border-black">
-        <p class="font-display text-size-2 lg:text-size-4 leading-none">{{ communityweekHighlights.stats.votes }}</p>
-        <p class="text-size--2 lg:text-size--1 uppercase mt-2">Votes</p>
-      </div>
-      <div class="py-4 lg:py-6 px-2 text-center border-r-2 border-black">
-        <p class="font-display text-size-2 lg:text-size-4 leading-none">{{ communityweekHighlights.stats.statements }}</p>
-        <p class="text-size--2 lg:text-size--1 uppercase mt-2">Statements</p>
-      </div>
-      <div class="py-4 lg:py-6 px-2 text-center">
-        <p class="font-display text-size-2 lg:text-size-4 leading-none">{{ communityweekHighlights.stats.participants }}</p>
-        <p class="text-size--2 lg:text-size--1 uppercase mt-2">Participants</p>
-      </div>
-    </div>
-    {% endif %}
-
-    <!-- Top three at-a-glance cards -->
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-16">
-      {% for s in communityweekHighlights.topStatements %}
-      <article class="border-2 border-black p-6 flex flex-col bg-white">
-        {% if s.label %}
-        <p class="font-bold uppercase text-size--1 text-gray mb-3 tracking-wide">{{ s.label }}</p>
-        {% endif %}
-        <p class="text-size-1 lg:text-size-2 mb-6 flex-grow">“{{ s.text }}”
-          {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
-        </p>
-        <div class="flex h-2 mb-2 overflow-hidden" aria-hidden="true">
-          <span class="block bg-black" style="width: {{ s.votes.agree }}%"></span>
-          <span class="block bg-red" style="width: {{ s.votes.disagree }}%"></span>
-          <span class="block bg-gray" style="width: {{ s.votes.pass }}%"></span>
-        </div>
-        <p class="text-size--4 text-gray">
-          {{ s.votes.agree }}% agree · {{ s.votes.disagree }}% disagree · {{ s.votes.pass }}% pass · {{ s.votes.total }} votes
-        </p>
-      </article>
-      {% endfor %}
-    </div>
-
-    <!-- Points of consensus -->
-    {% if communityweekHighlights.consensus and communityweekHighlights.consensus.length %}
-    <div class="mb-16">
-      <h3 class="font-display text-size-2 lg:text-size-2 uppercase mb-6">
-        Points of consensus
-      </h3>
-      <ol class="space-y-6">
-        {% for s in communityweekHighlights.consensus %}
-        <li class="border-b border-black pb-6 last:border-b-0">
-          <p class="text-size-0 lg:text-size-1 mb-3">“{{ s.text }}”
-            {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
-          </p>
-          <div class="flex h-2 mb-2 overflow-hidden" aria-hidden="true">
-            <span class="block bg-black" style="width: {{ s.votes.agree }}%"></span>
-            <span class="block bg-red" style="width: {{ s.votes.disagree }}%"></span>
-            <span class="block bg-gray" style="width: {{ s.votes.pass }}%"></span>
-          </div>
-          <p class="text-size--4 text-gray">
-            {{ s.votes.agree }}% agree · {{ s.votes.disagree }}% disagree · {{ s.votes.pass }}% pass · {{ s.votes.total }} votes
-            · agreed across both opinion groups (lowest group agree rate: {{ (s.minGroupAgreeRate * 100) | round | int }}%)
-          </p>
-        </li>
-        {% endfor %}
-      </ol>
-    </div>
-    {% endif %}
-
-    <!-- Where the cohort divided -->
-    {% if communityweekHighlights.divisive and communityweekHighlights.divisive.length %}
-    <div class="mb-16">
-      <h3 class="font-display text-size-2 lg:text-size-2 uppercase mb-6">
-        Where the cohort divided
-      </h3>
-      <ol class="space-y-8">
-        {% for s in communityweekHighlights.divisive %}
-        <li class="border-b border-black pb-8 last:border-b-0">
-          <p class="text-size-0 lg:text-size-1 mb-4">“{{ s.text }}”
-            {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
-          </p>
-          <div class="flex h-2 mb-2 overflow-hidden" aria-hidden="true">
-            <span class="block bg-black" style="width: {{ s.votes.agree }}%"></span>
-            <span class="block bg-red" style="width: {{ s.votes.disagree }}%"></span>
-            <span class="block bg-gray" style="width: {{ s.votes.pass }}%"></span>
-          </div>
-          <p class="text-size--4 text-gray mb-4">
-            Overall: {{ s.votes.agree }}% agree · {{ s.votes.disagree }}% disagree · {{ s.votes.pass }}% pass · {{ s.votes.total }} votes
-          </p>
-          <div class="space-y-2">
-            {% for g in s.groupAgreeRates %}
-            <div>
-              <div class="flex items-baseline justify-between mb-1">
-                <span class="text-size--2 lg:text-size--1 font-bold uppercase tracking-wide">Group {{ g.groupId + 1 }}</span>
-                <span class="text-size--4 text-gray">{{ (g.rate * 100) | round | int }}% agree · n={{ g.n }}</span>
-              </div>
-              <div class="flex h-2 bg-light-gold overflow-hidden border border-black" aria-hidden="true">
-                <span class="block bg-black" style="width: {{ (g.rate * 100) | round | int }}%"></span>
-              </div>
-            </div>
-            {% endfor %}
-          </div>
-        </li>
-        {% endfor %}
-      </ol>
-    </div>
-    {% endif %}
-
-    <!-- Opinion groups -->
-    {% if communityweekHighlights.groups and communityweekHighlights.groups.length %}
-    <div class="mb-16">
-      <h3 class="font-display text-size-2 lg:text-size-2 uppercase mb-4">
-        Opinion groups
-      </h3>
-      <p class="mb-8 text-size-0">
-        Polis identified two distinct opinion groups in the conversation.
-        Each is characterized below by the statements its members were
-        most distinctively likely to agree or disagree with.
-      </p>
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        {% for g in communityweekHighlights.groups %}
-        <div class="border-2 border-black p-6 bg-white">
-          <p class="font-bold uppercase text-size-0 mb-1 tracking-wide">Group {{ g.id + 1 }}</p>
-          <p class="text-size--2 text-gray mb-6">{{ g.size }} participant{% if g.size != 1 %}s{% endif %}</p>
-          <ol class="space-y-5">
-            {% for s in g.representativeStatements %}
-            <li>
-              <p class="font-bold uppercase text-size--2 text-gray mb-2 tracking-wide">
-                Most distinctively {{ s.voteType }}D with
-              </p>
-              <p class="text-size--1 lg:text-size-0 mb-2">“{{ s.text }}”
-                {% if s.isUserSubmitted %}<span class="text-size--2 text-gray font-normal whitespace-nowrap">— submitted by a participant</span>{% endif %}
-              </p>
-              <p class="text-size--4 text-gray">
-                {{ (s.inGroupRate * 100) | round | int }}% of this group {{ s.voteType }}d
-                (n={{ s.inGroupN }}), vs {{ (s.outGroupRate * 100) | round | int }}% of others
-                (n={{ s.outGroupN }})
-              </p>
-            </li>
-            {% endfor %}
-          </ol>
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-    {% endif %}
-
-    {% if communityweekHighlights.lastUpdated %}
-    <p class="text-size--4 text-gray">
-      Last updated: {{ communityweekHighlights.lastUpdated | readableDate }}.
-      Conversation data via
-      <a href="https://pol.is" class="inline-link" target="_blank" rel="noopener noreferrer">Polis</a>,
-      <a href="https://creativecommons.org/licenses/by/4.0/" class="inline-link" target="_blank" rel="noopener noreferrer">CC BY 4.0</a>.
-    </p>
-    {% endif %}
-  </section>
-  {% endif %}
 
   <!-- About the partners -->
   <section


### PR DESCRIPTION
Tomorrow morning's *Future of Social Connection* event is now framed as mid-conversation, not post-conversation. Voting stays open during the event.

## Template ([communityweeknyc/index.njk](src/site/communityweeknyc/index.njk))

- Section heading **"What emerged" → "What's emerging"** (present continuous — conversation is ongoing).
- Framing paragraph reframed verbatim per spec: *"Community Week NYC is running through May 15, with [voters] community builders contributing to this conversation so far. Below is a snapshot of what's emerging. Voting is still open — results will continue to shift as more people vote."*
- **"Voting closed May 14" banner removed.**
- **New muted intro paragraph** under the stats counter: *"Polis groups participants by how similarly they vote. Below are the patterns that have emerged so far — statements both groups agreed on, and what distinguishes the two clusters of voters from each other."*
- **New one-line intro** above "Points of consensus": *"Statements both opinion groups agreed on most strongly."*
- **Opinion-groups intro replaced**: *"Polis identified two clusters of voters based on patterns in how they voted. Each group is characterized below by the statements that set them apart from the other group — what was statistically distinctive about their voting, not what every group member voted."*
- **New caveat above lastUpdated**: *"This is a small sample (N voters, M groups). Findings are suggestive of patterns in the conversation, not definitive about NYC community builders as a whole. The full conversation is available on Polis."* — `N` and `M` interpolated from `stats.participants` and `stats.groups`.
- **"Where the cohort divided" subsection cut.** The "Most divided" at-a-glance card stays.
- **Polis embed moved below the results** with new H2 **"Add your voice"** and subtitle: *"Voting is still open. Take 2 minutes to vote on statements — or submit your own — and your input will appear in the results above."* Embed itself unchanged (same conversation id, placeholder guard, fallback link).

Page flow is now:
1. Hero + intro paragraphs
2. Results ("What's emerging")
3. Polis embed ("Add your voice")
4. About the partners
5. Closing / contact

## Script ([scripts/update_cwnyc_highlights.py](scripts/update_cwnyc_highlights.py))

- Drop `divisive` field from JSON output. `select_divisive()` and `_divisive_card()` deleted.
- Drop `conversationClosed: true` field. Empty-state payload loses it too.
- Everything else unchanged (topStatements, consensus, per-group representative with Fisher + Laplace priors).

## Workflow ([update-cwnyc-highlights.yml](.github/workflows/update-cwnyc-highlights.yml))

- Re-enabled hourly cron (`0 * * * *`).
- Header comment updated: *"Hourly refresh during Community Week event (May 15). Disable by commenting out the schedule block once the conversation is fully closed."*
- `workflow_dispatch` still available.

## Tests ([scripts/test_update_cwnyc_highlights.py](scripts/test_update_cwnyc_highlights.py))

- 3 divisive-specific tests dropped (largest-gap, skip-empty-group, divisive-card-isUserSubmitted).
- All other tests pass unchanged. **26 tests now, all green.**

## Verified before pushing

- ✅ All 26 unit tests pass locally
- ✅ Dry-run against live: 770 votes / 31 voters_in_conv / 35 voters / 8+23 group split / 38 statements
- ✅ Built site: headings render in correct order — "What's emerging" (h2) → "Points of consensus" (h3) → "Opinion groups" (h3) → "Add your voice" (h2)
- ✅ All seven new copy fragments present in dist HTML; all three stale fragments (`Voting closed May 14`, `What emerged`, `Where the cohort divided`) absent
- ✅ "Most divided" at-a-glance card still renders (topStatements path)
- ✅ JSON keys after script run: `consensus, groups, lastUpdated, stats, topStatements` — no `divisive`, no `conversationClosed`

## Workflow_dispatch verified on the branch

Triggered [run 25899158494](https://github.com/RadicalxChange/www/actions/runs/25899158494) on this branch via `gh workflow run --ref=cwnyc-event-mid-conversation`. Result:
- All 26 unit tests passed in CI
- Script ran end-to-end (fetched all five CSVs, computed everything)
- Commit step output: *"No substantive change — skipping commit."* (expected — data hasn't shifted in the few minutes since my push; this verifies the no-op path of the commit logic works correctly)

Post-merge, the hourly cron on `main` will pick up any data changes automatically. The first scheduled run will fire on the next hour boundary; you can also force a refresh via `gh workflow run update-cwnyc-highlights.yml --ref main` or the Actions tab.

## Note

GitHub Actions surfaced a deprecation notice on the run: `actions/checkout@v4` and `actions/setup-python@v5` are Node.js 20 actions, and Node 20 will be removed from runners on Sep 16, 2026. Out of scope for this PR but worth tracking for a follow-up bump to v5/v6 once available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)