### PR TITLE
Add The ⿻ Plural Stack paper: proposal page, blog post, PDF

### DIFF
--- a/src/data/updates/papers.js
+++ b/src/data/updates/papers.js
@@ -1,5 +1,14 @@
 module.exports = [
   {
+    url: "/updates/papers/the-plural-stack.pdf",
+    date: "2026-06-17",
+    title: "The ⿻ Plural Stack: Rebuilding our Digital Foundations from Protocol Up",
+    postType: "Paper",
+    postHeader: "The ⿻ Plural Stack: Rebuilding our Digital Foundations from Protocol Up",
+    postAuthor: "Andreas Fauler, et al",
+    series: [],
+  },
+  {
     url: "/updates/papers/The_Handbook_for_Radical_Local_Democracy.pdf",
     date: "2020-05-27",
     title: "The Handbook for Radical Local Democracy",

--- a/src/site/_data/proposals.yaml
+++ b/src/site/_data/proposals.yaml
@@ -21,3 +21,7 @@
 - title: Sectoral Data Bargaining
   shortDescription: |
     The Handbook is a toolkit for local policymakers and engaged citizens to take new approaches to some of the most pressing political problems. From voting and citizen engagement to investment in shared public goods to e-scooter regulation, the Handbook addresses crucial urban issues from a simple, clarifying point of view.
+
+- title: The ⿻ Plural Stack
+  shortDescription: |
+    A policy and design framework for digital infrastructure that is plural by architecture rather than extractive by default. The ⿻ Plural Stack charts a third path beyond US platform capitalism and Chinese state authoritarianism, built on open protocols that no single actor can capture, and offers the EU and a coalition of democratic middle powers a practical toolkit for building, funding, and adopting it.

--- a/src/site/projects/the-plural-stack.md
+++ b/src/site/projects/the-plural-stack.md
@@ -1,0 +1,67 @@
+---
+layout: "layouts/case-study.njk"
+slug: "the-plural-stack"
+title: "The ⿻ Plural Stack: Rebuilding our Digital Foundations from Protocol Up"
+postHeader: "The ⿻ Plural Stack: Rebuilding our Digital Foundations from Protocol Up"
+---
+
+*By Andreas Fauler · June 17, 2026*
+
+*Contact: [andreas@radicalxchange.org](mailto:andreas@radicalxchange.org)*
+
+**[Download the paper (PDF)](/updates/papers/the-plural-stack.pdf)**
+
+## Short description of the proposal or policy framework
+
+The ⿻ Plural Stack is a policy and design framework for building digital infrastructure that is plural by architecture rather than extractive by default. It argues that rules alone cannot deliver digital self-determination: regulation governing the conduct of dominant platforms leaves intact the architectural logic by which platform power accumulates. The framework proposes a third path, beyond US platform capitalism and Chinese state authoritarianism, that synthesises the best of each tradition: democratic and rights-based governance, dynamic market-driven innovation, and proactive public investment. It is grounded in ⿻ Plural protocol ecosystems, built on open protocols: formal specifications that permit many independent, interoperable implementations and thereby resist capture.
+
+It articulates ⿻ Plurality across three coequal dimensions: technical, economic, and social. Three layers of properties are distinguished within those dimensions: foundational properties that are enforceable by design (privacy-by-design, non-extractive value distribution, participatory governance); the emergent properties they enable (verifiable trust, composability, agency); and the super-emergent properties that follow when all three dimensions hold at once: sovereignty, resilience, and competitiveness. Through this architecture, each structural problem is answered in kind: systemic vulnerability becomes resilience, economic extraction becomes competitiveness, and strategic dependency becomes shared sovereignty.
+
+It provides a two-tiered structure for a ⿻ Plural protocol assessment framework, whose first gate asks whether a system is genuinely a protocol or a platform, and whose second tier scores foundational properties along a maturity spectrum. Finally, eight concrete policy recommendations are laid out. Its logic is transformation, not exclusion: it invites any actor who honors plural values, including those from the US or China.
+
+At its core, a ⿻ Plural protocol ecosystem rests on four core tenets:
+
+- **Ecosystems over Champions:** diverse actors cooperating and competing on shared infrastructure, rather than betting on a single national champion that becomes the next gatekeeper.
+- **Protocols over Platforms:** community-led protocols keep power plural and value fairness, rather than a single, centrally controlled platform.
+- **Decentralisation over Centralisation:** technical architecture that resists capture through unilateral control, so resilience rests with the system rather than with any one operator.
+- **Builder-, Creator-, and User-centred:** value flows back to the people who generate it, rather than being siphoned off by intermediaries.
+
+## What problem did this project seek to address?
+
+Core digital infrastructure is concentrated in a handful of providers, producing systemic vulnerability, extractive economics, and strategic dependency. The deeper issue is not the foreign origin of these platforms but the architectural logic of centralisation. A domestic "big tech" would behave the same way. The EU has responded with an ambitious regulatory programme including the Digital Markets Act, Digital Services Act, Data Act, and AI Act. These instruments discipline incumbents, but they regulate gatekeepers without constituting successors: they constrain how concentrated power behaves without changing the architecture that lets it concentrate in the first place.
+
+The stakes are now openly acknowledged. The European Parliament's January 2026 resolution on technological sovereignty (adopted 471–68) noted dependence on non-EU countries for over 80% of digital products, services, infrastructure, and intellectual property, a dependence that MEPs across the political spectrum described as amounting to a "digital colony."
+
+The ⿻ Plural Stack addresses this gap. Instead of only regulating, it asks what infrastructure should be built so that openness, privacy, and shared value are properties of the system itself. The aim is to move public investment and procurement from buying access to capturable platforms toward commissioning protocols that cannot be captured.
+
+## Was this developed in partnership with any organization or in response to a call for submissions, etc?
+
+The framework builds on the intellectual lineage of ⿻ Plurality, the body of work associated with E. Glen Weyl, Audrey Tang, and the RadicalxChange and ⿻ Plurality communities. The Plural Stack Initiative draws on Taiwan's digital-democracy practice (g0v, vTaiwan, the Presidential Hackathon), decentralisation-by-design, and recent policy initiatives such as "The European Way", "Rebalancing Europe's Digital Power" and the Eurostack. It is the collaborative work of an interdisciplinary group of researchers, legal experts, and practitioners from across the ⿻ Plurality community with contributors from the European Ethereum Institute, Identity Valley, the European Decentralisation Institute, and the Global Solutions Initiative. It is offered as a contribution to the policy debate on digital self-determination and as a companion to RxC's existing data- and governance-focused proposals.
+
+## How does this support more democratic outcomes?
+
+The framework relocates democratic values from policy promises into the architecture of the infrastructure itself.
+
+- **Capture-resistance by design:** Open protocols admit many interoperable implementations, so no single operator can become an unaccountable gatekeeper. Exit and forkability serve as structural checks on power.
+- **Non-extractive economics:** Value created by participants circulates among them rather than being siphoned off to a central rent collector, countering wealth concentration in the platform economy.
+- **Participatory governance:** Steering rights over shared infrastructure are distributed to the communities that depend on it, rather than concentrated in distant shareholders.
+- **Sovereignty as a designed property:** Because the architecture is governed by rules that no single actor can capture, self-determination rests on the technology rather than on jurisdiction. Democratic values are being turned into a competitive advantage rather than a compliance cost, and the model is made open to any democracy or middle power that adopts it.
+
+## Who are the key audiences or communities of participants?
+
+- **Policymakers across the EU and like-minded middle powers:** Those setting digital strategy, procurement, and industrial policy, who can commission and fund plural infrastructure rather than only regulating incumbents.
+- **Public-sector builders and procurement officials:** Agencies that can use the ⿻ Plural Protocol Assessment Framework to distinguish genuinely plural protocols from open-washing when buying or funding technology.
+- **Protocol and open-source communities:** Developers and stewards building interoperable alternatives in AI, social media, and governance.
+- **Civil society and digital-rights advocates:** Communities pressing for infrastructure that protects privacy, agency, and collective self-determination.
+- **Researchers and funders:** Those evaluating, measuring, and resourcing the transition to plural digital infrastructure.
+
+## Were there any related events, outcomes, or impacts?
+
+The ⿻ Plural Stack contributes to a growing international conversation about public digital infrastructure. It complements RxC's data-governance proposals (the Data Freedom Act, Data Escrows, Sectoral Data Bargaining) and Community Governance for Blockchain. The ⿻ Plural Stack Initiative continues to develop the ⿻ Plural Stack Assessment and aims to support digital sovereignty initiatives and protocol ecosystems in becoming fully plural, as well as supporting governments in implementing the policy recommendations and applying ⿻ Plurality more broadly. The initiative is open to additional collaborators.
+
+## Are there any testimonials, documents, assets, links or other ways we can illustrate this project?
+
+- [The Plural Stack: Rebuilding our Digital Foundations from Protocol Up (PDF)](/updates/papers/the-plural-stack.pdf) — Fauler, A., von Rosenstiel, A., Nuti, J., Ferroli, F. et al., Plurality Community, 2026.
+- Plurality: The Future of Collaborative Technology and Democracy — Audrey Tang & E. Glen Weyl — [plurality.net](https://plurality.net)
+- RadicalxChange — [radicalxchange.org](https://radicalxchange.org)
+- An interdisciplinary co-author group spanning RadicalxChange, the European Ethereum Institute, Identity Valley, the European Decentralisation Institute, and the Global Solutions Initiative.

--- a/src/site/updates/blog/2026-06-17_the-plural-stack.md
+++ b/src/site/updates/blog/2026-06-17_the-plural-stack.md
@@ -1,0 +1,71 @@
+---
+layout: "layouts/blog-post.njk"
+slug: "the-plural-stack"
+date: "2026-06-17"
+title: "Europe Doesn't Need Its Own Big Tech. It Needs Protocols Nobody Can Capture."
+postHeader: "Europe Doesn't Need Its Own Big Tech. It Needs Protocols Nobody Can Capture."
+postAuthor: "Andreas Fauler"
+---
+
+*Introducing the ⿻ Plural Stack, a third path for digital infrastructure.*
+
+The digital ground Europe stands on belongs to someone else. The search that shapes what it knows. The feeds that carry its public conversation. The AI models are now writing themselves into everything. Almost all of it is owned by a handful of US hyperscalers or built inside the Chinese state. That is not only an economic problem. It is a question of sovereignty, of democratic control, and of a strategic risk that compounds quietly while we look the other way.
+
+And this is no longer abstract. In January 2026 the European Parliament adopted a report on technological sovereignty by 471 votes to 68, noting that the EU depends on non-EU countries for more than 80% of its digital products, services, infrastructure, and intellectual property. MEPs from across the political spectrum called Europe a "digital colony."
+
+Europe's answer so far has been to regulate. The Digital Markets Act, the Digital Services Act, the Data Act, and the AI Act are the most ambitious bodies of digital rules anywhere in the world. But rules only govern how the gatekeepers behave. You can fine a monopolist for abusing its position without ever touching the architecture that handed it that position in the first place. Regulation disciplines power. It does not redistribute it.
+
+And there is something that regulation cannot fix at all. Even a "European Big Tech," headquartered safely inside the EU, would behave exactly like the incumbents it replaced. The problem was never geography. It is the centralising logic of the architecture, resulting in winner-takes-most. Move the head office to Europe, and you close the jurisdictional gap while leaving the architectural one wide open.
+
+So we ask a different question. Not "how do we better regulate extractive platforms?" but "what should we build instead?"
+
+**That's the ⿻ Plural Stack.**
+
+## Plural by architecture, not by promise
+
+The idea is simple. Build digital infrastructure on open protocols based on formal specifications that anyone can implement, many systems can interoperate across, and no single company can lock in. Think public highways, not private toll roads. IP, HTTP, SMTP, and the AT Protocol behind Bluesky are open roads anyone can build on. iMessage and WhatsApp are toll roads whose owner sets the terms. When openness, privacy, and shared value are built into the architecture, they stop being promises that an operator can revoke the moment incentives shift. They become facts of the system.
+
+## A third path: four core tenets
+
+So what does building plural-by-architecture actually commit you to? Four tenets, holding at every layer of the stack:
+
+- **Ecosystems over Champions:** diverse actors cooperating and competing on open infrastructure, rather than a single national champion becoming the next gatekeeper.
+- **Protocols over Platforms:** community-led protocols keep power plural and value shared, rather than a single, centrally controlled platform.
+- **Decentralisation over Centralisation:** technical architecture designed to resist capture by unilateral control, so no one actor can take the system down or lock it shut.
+- **Builder-, Creator- and User-centred:** infrastructure that rewards the people who generate the value, letting it flow back to them rather than being siphoned off by intermediaries.
+
+> "This vision is not driven by a nostalgia for an earlier internet. It is an attempt to redeem the internet's founding ethos at scale."
+
+## Three dimensions, three layers, and what they earn
+
+The ⿻ Plural Stack works across three coequal dimensions: technical, economic, and social. All three have to hold at once. Within them, it draws a sharp line between three layers of properties:
+
+- **Foundational properties you can enforce by design:** privacy-by-design, non-extractive value distribution, participatory governance.
+- **Emergent properties they unlock:** verifiable trust, composability, and real human agency.
+- **Super-emergent properties that appear only when all three dimensions are alive together:** sovereignty, resilience, and competitiveness.
+
+Insisting on all three is deliberate, and it is where most "open" systems quietly fail. Open-source code, even decentralised infrastructure, is necessary but never sufficient. A system whose code anyone can read and fork can still be captured economically when value is siphoned to a single rent collector, or socially when governance answers to distant shareholders. Email is the cautionary tale: an open protocol that became effectively centralised, not because the spec closed, but because its economics and governance drifted. Open in name, capturable in practice.
+
+That last layer is the whole point. Sovereignty can't be engineered into a single feature — it is earned. And it maps straight onto Europe's three deepest weaknesses, turning each into a strength: vulnerability becomes resilience, extraction becomes competitiveness, dependency becomes shared sovereignty.
+
+## A test for digital infrastructure
+
+So how do you tell a genuine plural infrastructure worth of generous public support? That is what the ⿻ Plural Protocol Assessment Framework is for. It starts with the question other frameworks skip: is this actually a protocol, or a platform wearing one as a costume? A Tier-1 pass/fail gate tests ownership, multiplicity, permissionless entry, and real interoperability. Whatever clears the gate is scored along a maturity spectrum across all three dimensions and classified as truly plural, emerging, or pseudo-plural. Over time, we want to turn this into a working instrument that can score any digital infrastructure, including Big Tech and publicly funded systems.
+
+## Transformation, not exclusion
+
+This is a third path, and it is deliberately not protectionism. It takes the best of three traditions: European rights and democracy, US entrepreneurial markets, and proactive public investment. It draws on Taiwan's digital democracy, on decentralisation-by-design, and Europe's own sovereignty agenda (The European Way, the Eurostack). The conclusion is a hopeful one: Europe and the democratic middle powers can lead here, not just catch up.
+
+And leading does not mean shutting anyone out. The real choice was never Big Tech versus Europe. It is extractive centralisation versus plural protocol ecosystems. The framework is open to any actor who honours plural values, including those from the US or China. Even the giants can be scored, rewarded for improving, and invited to change.
+
+## Come build it with us
+
+A paper is a starting point, not a finish line. The ⿻ Plural Stack only matters if it gets built, funded, and adopted.
+
+So this is an open invitation. If you build protocol ecosystems, let us map your work onto the stack and stress-test the assessment framework against real systems. If you are a policymaker, we will help translate plural infrastructure into procurement, funding, and strategy. And if you are a company ready to build on open foundations rather than rented ones, tell us what you need to make that bet.
+
+Protocol ecosystems, policymakers, companies: reach out. Let's define, design, and build the plural stack together.
+
+---
+
+Read the full paper: [The ⿻ Plural Stack: Rebuilding our Digital Foundations from Protocol Up (PDF)](/updates/papers/the-plural-stack.pdf). Learn more on the [⿻ Plural Stack policy proposal page](/projects/the-plural-stack/).


### PR DESCRIPTION
Publishes the **⿻ Plural Stack: Rebuilding our Digital Foundations from Protocol Up** paper across three surfaces, to pair with the [Global Solutions Initiative listing](https://www.global-solutions-initiative.org/publication/the-%e2%bf%bb-plural-stack/).

## Files added / changed
- **`src/site/updates/papers/the-plural-stack.pdf`** *(new)* — the downloadable paper.
- **`src/data/updates/papers.js`** *(modified)* — registers the PDF so it appears in the `/updates` Papers feed.
- **`src/site/_data/proposals.yaml`** *(modified)* — adds the Policy Proposals listing card (title "The ⿻ Plural Stack" + short description).
- **`src/site/projects/the-plural-stack.md`** *(new)* — the full policy-proposal page (author byline, contact `mailto:`, download link).
- **`src/site/updates/blog/2026-06-17_the-plural-stack.md`** *(new)* — the blog post, linking to the PDF and the proposal page.

## Live URLs (once merged)
- Policy proposal: `https://www.radicalxchange.org/projects/the-plural-stack/`
- Blog post: `https://www.radicalxchange.org/updates/blog/the-plural-stack/`
- PDF: `https://www.radicalxchange.org/updates/papers/the-plural-stack.pdf`
- Listing/index: `/projects/` (card) and `/updates/` (feed)

The blog and proposal share the `the-plural-stack` stem but live under different path prefixes (`/updates/blog/` vs `/projects/`), so there is no collision — confirmed in the build output.

## Notes for the reviewer
- **(a) Papers-feed author is abbreviated** to "Andreas Fauler, et al" (full citation: Fauler, A., von Rosenstiel, A., Nuti, J., Ferroli, F. et al.). Happy to expand to the full author list on request.
- **(b) Both pages are dated June 17, 2026** (one day ahead). I verified that neither Eleventy nor the site's `media`-feed logic filters future-dated content: a full build writes both pages and lists them at the top of the `/updates` feed today. So the future date does **not** hide anything — it only controls sort order.
- The ⿻ glyph (U+2FFB) renders as literal text in the built HTML (0 HTML entities, 0 replacement/tofu characters) on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)