### PR TITLE
Reframe site description around participatory governance for the age of AI

### DIFF
--- a/src/site/_data/metadata.js
+++ b/src/site/_data/metadata.js
@@ -1,5 +1,5 @@
 module.exports = {
   url: "https://www.radicalxchange.org", // use this only when absolute URLs are required
   defaultDescription:
-    "We are a community of activists, artists, entrepreneurs, and scholars committed to using mechanism design to inspire radical social change.",
+    "RadicalxChange Foundation is an international nonprofit advancing participatory governance for the age of AI, championing Plurality to keep human agency and democratic participation at the wheel.",
 };

--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -1,21 +1,19 @@
 ---
 layout: layouts/_base.njk
 introductionBlurb: |
-  **RadicalxChange empowers people to be the leaders, collaborators, stewards and funders we need to build more positive, participatory, pluralistic futures.**
+  **RadicalxChange Foundation is an international nonprofit advancing participatory governance for the age of AI.**
 
-  **We work across political, technological, cultural and social domains and divides to update social operating systems that are spiraling towards collapse.**
+  **Where Singularity imagines AI making human contribution obsolete, we advance [Plurality](https://plurality.net/): a philosophy that keeps human agency and democratic participation at the wheel and treats technology as a means of cooperating across difference.**
 
-  We support human agency and supercharge collective action with tools, methods and connections to cooperate across diversity, decentralize power, and make decision-making fast, fair and fun.
-
-  Some say that trajectories of monopolization and extraction, of polarization and tribalism, of exit or authoritarianism, are inevitable. We know otherwise: that leadership is found in diverse communities around the world, and that the systemic transitions we need are more joyful, creative and generative than possible through these narrow and exclusive frames. 
-
-  Together, we spark radical imagination and implement achievable alternatives to the status quo. We invite you to join us: the stakes are high and the moment is here. We’re the generation that gets to shape a future we can actually look forward to.
+  We leap from theory into practice, connecting a global movement that turns these ideas into working mechanisms, tests them in diverse contexts, and brings models of participation and collaborative governance to the grand challenges of our era.
 howBlurb: |
-  - A global [community](/community) modeling positive futures through experimentation
+  **We leap from theory into practice.** Our work includes:
 
-  - A stack of [tools and methods](/tools) facilitating collaboration, consensus-building and decentralized governance
+  - [Research](/updates) and civic-tech [prototypes](https://quadraticvote.radicalxchange.org/) that turn our ideas into working mechanisms
 
-  - [Proposals and projects](/projects) demonstrating practical applications and mainstream policy agendas
+  - [Projects with partners](/projects) that build "civic muscle" in communities and bring these methods to transform democratic and market institutions — from [Colorado](https://www.wired.com/story/colorado-quadratic-voting-experiment/) and [Nashville](https://www.forbes.com/sites/zengernews/2022/08/31/nashville-jersey-city-experiment-with-quadratic-voting---a-radical-step/) to [NYC](/wiki/nyc-qv/), the [UK](https://www.serpentinegalleries.org/whats-on/beyond-cultures-of-ownership/), [Brazil](https://www.economist.com/christmas-specials/2021/12/18/the-mathematical-method-that-could-offer-a-fairer-way-to-vote), Sydney, and more
+
+  - A global [community](/community) that tests these ideas in diverse contexts
 
   We deploy a range of tools developed within our community, including the Plural Stack:
 joinUsBlurb: |
@@ -30,6 +28,10 @@ joinUsBlurb: |
   We invite radical thinkers, builders, innovators and the curious to join our global [community](/community)—sign up for the [newsletter](http://eepurl.com/gywH7r) and our [monthly calls](https://calendar.google.com/calendar/u/0/embed?src=c_lucq4409c3e2db9j5vld22p8to@group.calendar.google.com&ctz=America/New_York) (first Wednesday of every month at 9am ET/3pm CET).
 
   [Contact us](mailto:info@radicalxchange.org) to co-design new experiments and tools for your community.
+aiTransitionBlurb: |
+  [Taiwan's world-leading embrace](https://www.wired.com/story/how-taiwans-unlikely-digital-minister-hacked-the-pandemic/) of this approach is well known. The next iteration comes from Japan, where the [Plurality book](https://plurality.net/read/) inspired [Team Mirai](https://www.techpolicy.press/japans-team-mirai-uses-tech-to-bolster-democracy-not-undermine-it/), a new independent party that won 11 parliamentary seats in 2026 using AI to facilitate broader democratic participation in understanding and shaping policy.
+
+  RadicalxChange's mission is to serve as the connective tissue that supports this ecosystem. The community work proves the method on the ground. Ambitious, economy-scale proposals bring these models of participation and collaborative governance to the grand challenges of our era. They serve the same agenda: helping humans steer the AI transition.
 homeConcepts:
   - name: Plural Voting
     href: /tools/plural-voting/
@@ -137,6 +139,14 @@ homeConcepts:
         </h2>
       </a>
       {% endfor %}
+    </div>
+  </div>
+  <div
+    class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9 space-y-line-3/2 mb-16"
+  >
+    <p class="font-bold uppercase">Steering the AI transition:</p>
+    <div class="markdown">
+      {{ aiTransitionBlurb | markdown | safe }}
     </div>
   </div>
   <div


### PR DESCRIPTION
## Summary

Reframes the public-facing description of the org around the new RadicalxChange Foundation copy: **participatory governance for the age of AI**, **Plurality vs. Singularity**, theory→practice, the place-based experiments, and the Taiwan→Japan / Team Mirai arc. Adapted to the existing homepage components and voice rather than pasted as a block.

### What changed and where

**`src/site/index.njk` (landing page)** — reuses the existing front-matter blurb + `markdown` section pattern; no restyle:
- **`introductionBlurb` (hero)** → "participatory governance for the age of AI" + the Plurality-vs-Singularity framing (links the [Plurality](https://plurality.net/) philosophy).
- **`howBlurb` ("We do this through")** → the theory→practice strand as bullets: [research](/updates) + civic-tech [prototypes](https://quadraticvote.radicalxchange.org/); [projects with partners](/projects) with the place-based experiments (Colorado, Nashville, [NYC](/wiki/nyc-qv/), UK, Brazil, Sydney); global [community](/community). Keeps the existing "Plural Stack" bridge line into the tools grid.
- **New "Steering the AI transition" section** → the Taiwan→Japan / [Team Mirai](https://www.techpolicy.press/japans-team-mirai-uses-tech-to-bolster-democracy-not-undermine-it/) arc and the "connective tissue" mission, using the same markdown-blurb component as the surrounding sections.

**`src/site/_data/metadata.js`** — `defaultDescription` (site-wide fallback for `<meta name="description">`, Open Graph, and Twitter cards) updated from the old "community of activists, artists, entrepreneurs, and scholars… mechanism design" line to the AI-age / Plurality framing.

### Link handling
- Internal links match the site convention: root-relative, **no** trailing slash for top-level pages (`/updates`, `/projects`, `/community`), trailing slash for the nested wiki page (`/wiki/nyc-qv/`).
- "research" → `/updates` (RxC's publications feed). Note: the `/updates` **Papers** filter is a client-side checkbox only — there is no stable filtered URL to point at — so `/updates` is the correct, on-brand target.
- "Plurality" philosophy → `https://plurality.net/`; "Plurality book" → `https://plurality.net/read/` (kept distinct).
- External links authored **plainly** (no `target="_blank"`/`rel`) — this matches the existing markdown-blurb convention (markdown-it isn't configured to add them, and existing blurb links e.g. the newsletter/calendar are plain).
- **Sydney** left **unlinked** as instructed — see Follow-ups.

### Build
`npm run build` succeeds. Verified the rendered `dist/index.html`: all internal/external anchors resolve as intended and "Sydney" renders as plain text.

## Recommendations (NOT done — larger / judgment-dependent)

- **`src/site/about/index.njk`** — the About intro ("What is RadicalxChange?") and "We do this through" / focus-area cards still use the older "transformative systems change… cooperate across diversity" framing. Bringing it fully into line with the AI-age/Plurality framing is a page-level rewrite (multiple blurbs, the 4 focus cards, the "Foundation" blurb) and a content-owner decision, so left for a dedicated pass.
- **`src/site/vision/index.njk`** — already references Taiwan and Japan and is broadly compatible, but doesn't yet name Plurality-vs-Singularity or Team Mirai. Worth a deliberate edit by the team rather than a drive-by.
- **Homepage tagline / marquee** — the H1 mobile tagline and the sticky marquee still read "Enabling cooperation across diversity for the common good." Updating the brand tagline to the AI-age framing is a brand decision, not a consistency fix — flagging only.
- **Japan / Team Mirai case study** — the arc is now summarized on the homepage; a fuller wiki/case-study page (à la the Colorado/NYC QV pages) would be a natural follow-up but is net-new content.
- **`src/site/about/index.njk` focus cards / `index.njk` "We focus on" cards** — left unchanged (still on-message); revisit if the four-pillar framing is being retired.

## Follow-ups

- **Portuguese translation** — the new homepage copy and the updated `defaultDescription` need PT versions. Note: `portuguese/` is **archived markdown** (`página-inicial.md`, `quem-somos.md`, `comunidade.md`), not built into the live site (per `portuguese/README.md`), and already reflects much older framing — so no live PT strings regressed, but a re-translation is a known gap.
- **Sydney link** — intentionally left unlinked; please supply a source URL if one exists.
- **Economist link** — `https://www.economist.com/christmas-specials/2021/12/18/the-mathematical-method-that-could-offer-a-fairer-way-to-vote` returns **403** to automated checks (Economist bot-block / hardened paywall). The URL appears correct and is unchanged from prior usage; flagging in case the team wants an archive/alt link. All other external links return 200.
- **Facts to verify** — the "Team Mirai won 11 parliamentary seats in 2026" claim comes directly from the supplied copy and is presented as-is; confirm before publication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
