### PR TITLE
Restructure landing page to lead with the Foundation description

### DIFF
--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -1,21 +1,17 @@
 ---
 layout: layouts/_base.njk
-introductionBlurb: |
-  **RadicalxChange Foundation is an international nonprofit advancing participatory governance for the age of AI.**
-
-  **Where Singularity imagines AI making human contribution obsolete, we advance [Plurality](https://plurality.net/): a philosophy that keeps human agency and democratic participation at the wheel and treats technology as a means of cooperating across difference.**
-
-  We leap from theory into practice, connecting a global movement that turns these ideas into working mechanisms, tests them in diverse contexts, and brings models of participation and collaborative governance to the grand challenges of our era.
-howBlurb: |
-  **We leap from theory into practice.** Our work includes:
-
-  - [Research](/updates) and civic-tech [prototypes](https://quadraticvote.radicalxchange.org/) that turn our ideas into working mechanisms
-
-  - [Projects with partners](/projects) that build "civic muscle" in communities and bring these methods to transform democratic and market institutions — from [Colorado](https://www.wired.com/story/colorado-quadratic-voting-experiment/) and [Nashville](https://www.forbes.com/sites/zengernews/2022/08/31/nashville-jersey-city-experiment-with-quadratic-voting---a-radical-step/) to [NYC](/wiki/nyc-qv/), the [UK](https://www.serpentinegalleries.org/whats-on/beyond-cultures-of-ownership/), [Brazil](https://www.economist.com/christmas-specials/2021/12/18/the-mathematical-method-that-could-offer-a-fairer-way-to-vote), Sydney, and more
-
-  - A global [community](/community) that tests these ideas in diverse contexts
-
-  We deploy a range of tools developed within our community, including the Plural Stack:
+heroHeadline: |
+  RadicalxChange Foundation is an international nonprofit advancing participatory governance for the age of AI.
+heroSubhead: |
+  Where Singularity imagines AI making human contribution obsolete, we advance [Plurality](https://plurality.net/) — a philosophy that keeps human agency and democratic participation at the wheel, and treats technology as a means of cooperating across difference.
+theoryPracticeBlurb: |
+  We leap from theory into practice. Our work spans [research](/updates), [civic-tech prototypes](https://quadraticvote.radicalxchange.org/) that turn our ideas into working mechanisms, [partnerships](/projects) that build "civic muscle" in communities, and a global [community](/community) that tests these ideas across very different contexts. Together, these have begun to transform democratic and market institutions — in [Colorado](https://www.wired.com/story/colorado-quadratic-voting-experiment/), [Nashville](https://www.forbes.com/sites/zengernews/2022/08/31/nashville-jersey-city-experiment-with-quadratic-voting---a-radical-step/), [New York](/wiki/nyc-qv/), the [UK](https://www.serpentinegalleries.org/whats-on/beyond-cultures-of-ownership/), [Brazil](https://www.economist.com/christmas-specials/2021/12/18/the-mathematical-method-that-could-offer-a-fairer-way-to-vote), Sydney, and beyond.
+nationalScaleBlurb: |
+  This approach is already reshaping politics at the national scale. [Taiwan's world-leading embrace](https://www.wired.com/story/how-taiwans-unlikely-digital-minister-hacked-the-pandemic/) is well known; the next iteration is emerging in Japan, where the [Plurality book](https://plurality.net/read/) inspired [Team Mirai](https://www.techpolicy.press/japans-team-mirai-uses-tech-to-bolster-democracy-not-undermine-it/) — a new independent party that won 11 parliamentary seats in 2026, using AI to help citizens understand and shape policy.
+missionBlurb: |
+  RadicalxChange's role is to be the connective tissue for this ecosystem: community work proves the methods on the ground, while ambitious, economy-scale proposals carry them to the grand challenges of our era. Both serve the same goal — helping humans, not algorithms, steer the AI transition.
+toolsBlurb: |
+  The mechanisms behind the work — the Plural Stack:
 joinUsBlurb: |
   If you're...
 
@@ -28,10 +24,6 @@ joinUsBlurb: |
   We invite radical thinkers, builders, innovators and the curious to join our global [community](/community)—sign up for the [newsletter](http://eepurl.com/gywH7r) and our [monthly calls](https://calendar.google.com/calendar/u/0/embed?src=c_lucq4409c3e2db9j5vld22p8to@group.calendar.google.com&ctz=America/New_York) (first Wednesday of every month at 9am ET/3pm CET).
 
   [Contact us](mailto:info@radicalxchange.org) to co-design new experiments and tools for your community.
-aiTransitionBlurb: |
-  [Taiwan's world-leading embrace](https://www.wired.com/story/how-taiwans-unlikely-digital-minister-hacked-the-pandemic/) of this approach is well known. The next iteration comes from Japan, where the [Plurality book](https://plurality.net/read/) inspired [Team Mirai](https://www.techpolicy.press/japans-team-mirai-uses-tech-to-bolster-democracy-not-undermine-it/), a new independent party that won 11 parliamentary seats in 2026 using AI to facilitate broader democratic participation in understanding and shaping policy.
-
-  RadicalxChange's mission is to serve as the connective tissue that supports this ecosystem. The community work proves the method on the ground. Ambitious, economy-scale proposals bring these models of participation and collaborative governance to the grand challenges of our era. They serve the same agenda: helping humans steer the AI transition.
 homeConcepts:
   - name: Plural Voting
     href: /tools/plural-voting/
@@ -57,6 +49,8 @@ homeConcepts:
 {% import "components/menu.njk" as menu %}
 <!-- prettier-ignore -->
 {% import "components/footer.njk" as footer %}
+<!-- prettier-ignore -->
+{% import "components/action-button.njk" as actionButton %}
 
 <!-- prettier-ignore -->
 {{ menu.render() }}
@@ -77,51 +71,57 @@ homeConcepts:
       </a>
     </h1>
   </header>
+  <!-- 1. HERO: foundation headline + Singularity-vs-Plurality subhead -->
   <div
     class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9 space-y-line-3/2 mb-16"
   >
-    <div class="markdown">
-      {{ introductionBlurb | markdown | safe }}
+    <h2 class="font-bold text-size-2 lg:text-size-4">
+      {{ heroHeadline }}
+    </h2>
+    <div class="markdown text-size-0 lg:text-size-1">
+      {{ heroSubhead | markdown | safe }}
     </div>
     {{ caller() if caller }}
   </div>
-  <div class="col-span-columns lg:col-end-gutter-9 mb-16">
-    <p class="font-bold uppercase">We focus on:</p>
-    <ol class="w-full mt-8 grid grid-cols-1 lg:grid-cols-2 gap-x-4 gap-y-4 max-w-3xl mx-auto">
-      <li class="flex flex-col justify-between h-64 w-full border-2 m-auto p-4">
-        <p class="font-bold">Democratic Transformation</p>
-        <p class="italic text-sm">How should we govern?</p>
-        <p>Forging the foundations of 21st century governance</p>
-      </li>
-      <li class="flex flex-col justify-between h-64 w-full border-2 m-auto p-4">
-        <p class="font-bold">Resilient Decentralization</p>
-        <p class="italic text-sm">How should we build?</p>
-        <p>Accelerating distributed participation and local creativity to solve global problems</p>
-      </li>
-      <li class="flex flex-col justify-between h-64 w-full border-2 m-auto p-4">
-        <p class="font-bold">Collective Agency</p>
-        <p class="italic text-sm">Who are "we"?</p>
-        <p>Empowering "plural publics" to form and act in the face of shared challenges</p>
-      </li>
-      <li class="flex flex-col justify-between h-64 w-full border-2 m-auto p-4">
-        <p class="font-bold">Imaginative Hope</p>
-        <p class="italic text-sm">Where are we going?</p>
-        <p>Inspiring curiosity, experimentation and agency to shape possible futures</p>
-      </li>
-    </ol>
-  </div>
+  <!-- 2. Theory -> practice -->
   <div
     class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9 space-y-line-3/2 mb-16"
   >
-    <p class="font-bold uppercase">We do this through:</p>
+    <p class="font-bold uppercase">From theory to practice:</p>
     <div class="markdown">
-      {{ howBlurb | markdown | safe }}
+      {{ theoryPracticeBlurb | markdown | safe }}
     </div>
   </div>
-  <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9 self-center mb-16">
-    <div 
+  <!-- 3. National-scale proof, with pull-stat -->
+  <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9 mb-16">
+    <p class="font-bold uppercase mb-8">Proof at the national scale:</p>
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-x-8 gap-y-8 items-center">
+      <div class="markdown lg:col-span-2">
+        {{ nationalScaleBlurb | markdown | safe }}
+      </div>
+      <div class="flex flex-col justify-center h-full border-2 p-6">
+        <p class="font-display text-size-xl/display leading-none">11</p>
+        <p class="font-bold uppercase mt-3">
+          parliamentary seats won by Japan's Team Mirai in 2026
+        </p>
+      </div>
+    </div>
+  </div>
+  <!-- 4. Mission close -->
+  <div
+    class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9 space-y-line-3/2 mb-16"
+  >
+    <p class="font-bold uppercase">Our role:</p>
+    <div class="markdown">
+      {{ missionBlurb | markdown | safe }}
+    </div>
+  </div>
+  <!-- 5. Plural Stack: condensed, demoted to a compact tile row -> /tools -->
+  <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9 mb-16">
+    <p class="font-bold uppercase mb-8">{{ toolsBlurb }}</p>
+    <div
       id="concepts"
-      class="w-full mx-auto grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 gap-x-8 gap-y-16 lg:gap-y-12"
+      class="grid grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-8"
     >
       {% for concept in homeConcepts%}
       <a
@@ -129,24 +129,19 @@ homeConcepts:
         href="{{ concept.href }}"
       >
         <div></div>
-        <div class="w-full max-w-xs">
+        <div class="w-full max-w-[7rem]">
           {{ concept.element | safe }}
         </div>
         <h2
-          class="lg:h-line-2 mt-6 text-center text-size-2 lg:text-size-0 group-hover:thick-link"
+          class="mt-3 text-center text-size--1 group-hover:thick-link"
         >
           {{ concept.name }}
         </h2>
       </a>
       {% endfor %}
     </div>
-  </div>
-  <div
-    class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9 space-y-line-3/2 mb-16"
-  >
-    <p class="font-bold uppercase">Steering the AI transition:</p>
-    <div class="markdown">
-      {{ aiTransitionBlurb | markdown | safe }}
+    <div class="mt-8">
+      {{ actionButton.render(href="/tools", label="Explore the Plural Stack") }}
     </div>
   </div>
   <div


### PR DESCRIPTION
> **Do not merge — for review.** Structural landing-page edit requested as a follow-up to #229.

## What this does

Reshapes the homepage so the new RadicalxChange Foundation description **leads** the page rather than being slotted between the pre-existing modules, and swaps in the edited-for-flow copy. Every link and target is preserved exactly; internal links keep the site's convention (root-relative; no trailing slash for top-level pages, trailing slash for `/wiki/nyc-qv/`). Reuses existing components, type scale, and the Plural Stack animations — this is a content/structure change, **not** a visual redesign.

## Before → after section map

| # | Before (main) | After (this PR) |
|---|---|---|
| 1 | Logo header | Logo header *(unchanged)* |
| 2 | Intro blurb (3 paras) | **Hero** — foundation line promoted to headline + Singularity-vs-Plurality subhead |
| 3 | "We focus on:" — 4 focus-area cards | **From theory to practice** — research / prototypes / partnerships / community + Colorado→Sydney place links |
| 4 | "We do this through:" — bullet list | **Proof at the national scale** — Taiwan / Japan / Team Mirai, with an **"11" pull-stat** card |
| 5 | Plural Stack — large 4-up animation grid | **Our role** — connective-tissue mission close |
| 6 | "Steering the AI transition:" blurb | **The Plural Stack** — condensed compact tile row → `/tools` |
| 7 | "We invite you to join us:" wayfinding | Wayfinding block *(unchanged)* |
| — | sticky marquee | sticky marquee *(unchanged)* |

## Relocations (nothing hard-deleted)

- **Four focus areas** ("Democratic Transformation / Resilient Decentralization / Collective Agency / Imaginative Hope") — **already present on `/about`** under "Our current program of work focuses on" ([src/site/about/index.njk](src/site/about/index.njk)). They were duplicated on the homepage, so this removes the homepage copy; no move required.
- **"We do this through" bullet list** — superseded by the new *From theory to practice* paragraph, which carries the same four strands and **all the same links** (`/updates`, prototypes, `/projects`, `/community`, Colorado, Nashville, NYC→New York, UK, Brazil, Sydney).
- **Older rallying paragraphs** ("Some say that trajectories of monopolization…", "Together, we spark radical imagination…") — these were already removed from the homepage in #229; their themes live on [/vision](src/site/vision/index.njk) and [/about](src/site/about/index.njk). No further action.

## Implementation notes

- **Hero headline** is a real `<h2>` using existing `text-size-2 lg:text-size-4` (logo stays the `<h1>`); subhead rendered from markdown so the [Plurality](https://plurality.net/) link is preserved.
- **Pull-stat** reuses the existing `border-2` card treatment + `font-display` numerals (`11`) — no new styles.
- **Plural Stack** keeps the four `homeConcepts` animations and the `#concepts` hover/intersection JS contract (`children[1].children[0]`); only sizing/grid classes changed, plus an `action-button` link to `/tools` framing them as "the mechanisms behind the work."

## Verification

- `npm run build` passes (439 files written, exit 0).
- Audited the rendered `dist/index.html`: section order is Hero → Theory→practice → National-scale (+pull-stat) → Our role → Plural Stack → Wayfinding; all 13 body links resolve to the exact intended targets; "Sydney" remains unlinked; the three removed blocks are absent.
- Visually checked locally (served `dist/`) at desktop (1280) and mobile (375): hero headline + subhead render cleanly; the "11" pull-stat sits beside the paragraph on desktop and stacks full-width on mobile; the compact Plural Stack tiles + "Explore the Plural Stack" button render correctly. *(Screenshots captured during review; GitHub's CLI can't attach images to the PR body, happy to drop them in a comment.)*

## Follow-ups (carried over / unchanged)

- **Portuguese** — `portuguese/` is archived markdown, not built into the live site, and already reflects older framing; the restructured homepage copy will need a PT pass if/when the translation is revived.
- **Sydney** — still intentionally unlinked; supply a source URL if one exists.
- **Economist link** — returns 403 to automated checks (bot-block / hardened paywall); URL appears correct and unchanged.
- **"11 parliamentary seats in 2026"** — taken verbatim from the supplied copy and now given pull-stat prominence; please confirm before publishing.

## Out of scope (flagging, not done)

- The homepage **tagline/marquee** ("Enabling cooperation across diversity for the common good") still reflects the older framing — a brand decision, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
