### PR TITLE
Remove the "Enabling cooperation across diversity" tagline

### DIFF
--- a/src/site/index.njk
+++ b/src/site/index.njk
@@ -64,10 +64,7 @@ homeConcepts:
       class="font-display text-size-display lg:text-size-lg/display uppercase"
     >
       <a href="/">
-        <span class="inline lg:hidden"
-          >RxC is Enabling cooperation across diversity for the common good</span
-        >
-        {{ logo.render(classes="hidden lg:inline-block align-top") }}
+        {{ logo.render(classes="inline-block align-top") }}
       </a>
     </h1>
   </header>
@@ -150,26 +147,6 @@ homeConcepts:
     <p class="font-bold uppercase">We invite you to join us:</p>
     <div class="markdown">
       {{ joinUsBlurb | markdown | safe }}
-    </div>
-  </div>
-  <div
-    class="sticky bottom-0 hidden lg:block col-start-margin-1 col-end-column-10 w-full pt-2 bg-white font-display text-size-lg/display"
-  >
-    <div class="message-marquee">
-      <div class="marquee__inner">
-        <span class="uppercase mx-6 whitespace-nowrap"
-          >Enabling cooperation across diversity for the common good</span
-        >
-        <span aria-hidden="true" class="uppercase mx-6 whitespace-nowrap"
-          >Enabling cooperation across diversity for the common good</span
-        >
-        <span aria-hidden="true" class="uppercase mx-6 whitespace-nowrap"
-          >Enabling cooperation across diversity for the common good</span
-        >
-        <span aria-hidden="true" class="uppercase mx-6 whitespace-nowrap"
-          >Enabling cooperation across diversity for the common good</span
-        >
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Removes the "Enabling cooperation across diversity for the common good" tagline from the landing page, everywhere it appeared.

## What changed (`src/site/index.njk`)

1. **Desktop sticky marquee banner** — deleted the bottom `sticky bottom-0 … message-marquee` block that scrolled the tagline across the foot of the page.
2. **Mobile header tagline** — removed the mobile-only `<span>` ("RxC is Enabling cooperation across diversity for the common good") that served as the mobile wordmark, and switched the logo to render on all viewports (was `hidden lg:inline-block`) so the **mobile header now shows the RadicalxChange logo** rather than being left empty.

The `.logo` class is already responsive (`width: 90.27vw` on mobile — the same treatment the footer's logo uses), so the logo fits a 375px viewport without overflow.

## Verification

- `npm run build` passes (exit 0).
- Built `dist/index.html` contains **0** occurrences of the tagline; runtime DOM check confirms no `.message-marquee` and no `.sticky.bottom-0` elements.
- Checked locally (served `dist/`):
  - **Mobile (375px):** header shows the full RadicalxChange logo, no tagline, header not empty.
  - **Desktop (1280px):** no sticky tagline banner at the bottom.

## Follow-up (optional, not done)

- `src/site/_includes/css/message-marquee.css` is now unused — the marquee was its only consumer (no other markup references `message-marquee` / `marquee__inner`). Left in place to keep this change focused; safe to prune (remove the file + its `@import` in `styles.css`) in a separate commit if desired.

> Branched from `main`. Independent of the open review PRs #230/#231 (no overlapping lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
