### PR TITLE
Foundations: light-surface fix, locked palette, spacing + type tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,13 @@ white/yellow-on-black only — **never** yellow/white on yellow/white, and never
 yellow text on white.
 
 `gray` and `red` remain in the config but are **restricted, non-brand** colors kept
-only for functional data-viz on the Community Week NYC microsite. Don't use them on
-brand surfaces.
+only for functional data-viz on the Community Week NYC microsite (pass / disagree vote
+bars). **They are retained intentionally — please don't "tidy them up."** There the
+colors carry _meaning_ (data encoding), not decoration, so they're a different category
+from the brand surface and removing them would break the vote bars. The brand rule
+(black / white / yellow) governs brand surfaces; a data-viz legend is exempt. Revisit
+the encoding only if/when CWNYC gets a visual refresh on its own merits. Don't use them
+on brand surfaces, and don't introduce new usages.
 
 ### Surface & color scheme
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,41 @@ The RadicalxChange www site is built on [11ty](https://www.11ty.dev/). It's styl
 
 ## Design
 
+> A refinement effort is tightening the site's craft _within_ the existing brand
+> (hierarchy, spacing, component consistency, restraint). See `DESIGN_DIRECTION.md`
+> for the audit and plan. The tokens below are the shared foundation that work builds on.
+
+### Palette
+
+Three brand colors, nothing else:
+
+| Token            | Hex       | Role                                                         |
+| ---------------- | --------- | ----------------------------------------------------------- |
+| `black`          | `#000000` | Primary ink; black section bands ("the big moments").       |
+| `white`          | `#FFFFFF` | Default page surface.                                        |
+| `golden-fizz`    | `#EDFF38` | Brand **yellow** — punctuation only.                        |
+
+**Yellow is punctuation, not wallpaper.** Use it for accents (underlines, icon
+circles, highlight marks, number circles, a single key callout) and the rare,
+countable full-bleed jolt (newsletter, donate CTA, 404). Reach for **black
+sections** — not yellow fills — for big confident moments. Default surface is white.
+
+**Contrast rule (ADA), from the Brand Book:** black-on-yellow, black-on-white, or
+white/yellow-on-black only — **never** yellow/white on yellow/white, and never
+yellow text on white.
+
+`gray` and `red` remain in the config but are **restricted, non-brand** colors kept
+only for functional data-viz on the Community Week NYC microsite. Don't use them on
+brand surfaces.
+
+### Surface & color scheme
+
+`global.css` sets `color-scheme: light` and a white `body` background so no page can
+fall through to the browser's dark canvas (which previously made black text invisible
+in OS dark mode). These live on low-specificity selectors, so any utility
+(`bg-black`, `bg-golden-fizz`, a page's `bodyBg`) still overrides them — intentionally
+dark or yellow bands are unaffected.
+
 ### Grid
 
 Pages are laid out on grids. A grid has fixed-width margins, fixed-width gutters and fluid columns. Desktop pages are on a 12-column or 16-column grid. Mobile pages are on a 4-column grid.
@@ -48,11 +83,44 @@ We use TailWind's built-in scale for general size and space. These utilities use
 
 For typography heavy pages, we use a multiple of line height for vertical spacing. The utilities use `em` units.
 
+#### Section rhythm
+
+For the gaps **between** structural blocks, prefer the documented rhythm tokens over
+ad-hoc `mb-16` / `mb-8` one-offs, so every page shares one calm cadence:
+
+| Token     | Value                    | Use                                   |
+| --------- | ------------------------ | ------------------------------------- |
+| `section` | `clamp(4rem, 8vw, 8rem)` | Between major page sections.          |
+| `block`   | `clamp(2rem, 4vw, 3rem)` | Between blocks within a section.      |
+| `element` | `1.5rem`                 | Between elements within a block.      |
+
+Apply as any Tailwind spacing utility, e.g. `mb-section`, `space-y-block`, `py-section`,
+`gap-element`.
+
 ### Typography
 
 We use a [fluid type scale](https://utopia.fyi/blog/designing-with-fluid-type-scales) for almost all text. This scale provides a base text size and "steps" up and down from that. If you assign a step size to text, it will automatically scale relative to the width of the browser.
 
 For text written in Messer font, use font-size in the `vw` unit instead.
+
+#### Type roles
+
+Two families, a small set of roles. **Only one Messer weight is licensed for web**
+(`MesserV2.0-Condensed`, 400) — so display hierarchy comes from **size, not weight**.
+Keep to these roles rather than inventing per-page sizes:
+
+| Role                | Font (`font-…`)        | Treatment                                   | Notes                                            |
+| ------------------- | ---------------------- | ------------------------------------------- | ------------------------------------------------ |
+| Display / page title | `display` (Messer)     | **ALL CAPS**, `size-lg/display`+            | One per page. Caps only — Messer is a caps face. |
+| Hero statement      | `display` (Messer caps) | short, oversized                            | Keep it short (≈4–8 words); long copy → standfirst. |
+| Section header      | `body` bold (Suisse)   | `size-2`, with a hairline rule beneath      | Pairs with the eyebrow below.                    |
+| Eyebrow / kicker    | `body` bold (Suisse)   | uppercase, `size--1`, letter-spaced, quiet  | A small label, **not** a headline.               |
+| Body                | `body` (Suisse)        | `size-0`                                    | Brand body face is Suisse Book.¹                 |
+| Meta (author/date/tag) | `body` (Suisse)     | `size--1`                                   | One consistent size for all metadata.            |
+
+¹ The Brand Book specifies **Suisse Int'l Book** for paragraph text; today `font-body`
+resolves to Suisse Int'l _Regular_. A small, deliberate drift to reconcile in a later
+typography pass — flagged, not silently changed.
 
 ## Code Layout
 

--- a/src/site/_includes/components/popup.njk
+++ b/src/site/_includes/components/popup.njk
@@ -38,7 +38,7 @@
             <div
               class="sticky bottom-0 left-0 lg:px-16 lg:rounded-tvinfo items-center"
             >
-              <button class="block bg-light-gold rounded-oval py-3 px-8 mx-auto mb-4 mt-12">
+              <button class="block bg-golden-fizz rounded-oval py-3 px-8 mx-auto mb-4 mt-12">
                 <a
                   class="text-black text-size--2 uppercase"
                   href="{{ link }}"

--- a/src/site/_includes/css/global.css
+++ b/src/site/_includes/css/global.css
@@ -1,3 +1,23 @@
+/* Lock the site to a light surface.
+
+   Without this, pages that don't paint their own background fall through to the
+   browser's default canvas — which is BLACK for visitors whose OS is in dark
+   mode, rendering black body text invisible (Updates, articles, Search, Wiki…).
+   `color-scheme: light` also keeps native controls and scrollbars light.
+
+   This is a DEFAULT, not an override: the background/color live on the low-
+   specificity `body` element selector, so any Tailwind utility on a page
+   wrapper or section (bg-black, bg-golden-fizz, text-white, or a page's
+   `bodyBg`) still wins. Intentionally-dark bands are unaffected. */
+:root {
+  color-scheme: light;
+}
+
 html {
   scroll-behavior: smooth;
+}
+
+body {
+  background-color: theme("colors.white");
+  color: theme("colors.black");
 }

--- a/src/site/_includes/css/link.css
+++ b/src/site/_includes/css/link.css
@@ -1,8 +1,10 @@
 .see-more-link {
-  @apply text-gray;
+  /* De-emphasized via opacity on brand black rather than an off-brand grey. */
+  color: theme("colors.black");
+  opacity: 0.6;
 
   &:hover {
-    @apply text-black;
+    opacity: 1;
   }
 }
 

--- a/src/site/about/index.njk
+++ b/src/site/about/index.njk
@@ -234,7 +234,7 @@ supporters:
         <p>{{ article.date | readableDate }}</p></a
       >
       <div
-        class="about_press-description z-10 absolute top-1/2 left-1/8 w-max p-2 bg-light-black text-white text-size--4"
+        class="about_press-description z-10 absolute top-1/2 left-1/8 w-max p-2 bg-black text-white text-size--4"
       >
         {{ article.title }}
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,15 +39,25 @@ module.exports = {
       body: ["Suisse Intl", "sans-serif"],
     },
     colors: {
-      "golden-fizz": "#EDFF38",
-      "light-gold": "#FAFFC3",
-      red: "#C53030",
+      // ---- Brand palette (locked) — the only colors for brand surfaces ----
+      // Per the RxC Brand Book: black + white + yellow, nothing else. Yellow is
+      // punctuation (marks, underlines, icon circles, one callout), never
+      // wallpaper. Contrast rule (ADA): black-on-yellow, black-on-white, or
+      // white/yellow-on-black only — never yellow/white on yellow/white.
       black: "#000000",
-      "light-black": "#010101",
       white: "#FFFFFF",
-      gray: "#6C6C6C",
+      "golden-fizz": "#EDFF38", // brand yellow
+
       transparent: "transparent",
       current: "currentColor",
+
+      // ---- Restricted (non-brand) — do NOT use on brand surfaces ----
+      // Retained only for functional data-visualization on the Community Week
+      // NYC microsite (pass / disagree vote bars). Not part of the brand
+      // system and slated for removal when that page is redesigned. Do not
+      // introduce new usages — reach for the brand palette above instead.
+      gray: "#6C6C6C",
+      red: "#C53030",
     },
     extend: {
       borderRadius: {
@@ -85,6 +95,13 @@ module.exports = {
       },
       height: { 36: "9rem" },
       spacing: {
+        // Section rhythm — documented vertical-spacing scale (see README →
+        // Design → Spacing). Use these for the gaps BETWEEN structural blocks
+        // (e.g. mb-section, space-y-block, py-section) instead of ad-hoc
+        // mb-16 / mb-8 one-offs, so pages share one calm, consistent rhythm.
+        section: "clamp(4rem, 8vw, 8rem)", // between major page sections
+        block: "clamp(2rem, 4vw, 3rem)", // between blocks within a section
+        element: "1.5rem", // between elements within a block
         margin: "1rem",
         "lg/margin": "1.5rem",
         ymargin: "1rem",


### PR DESCRIPTION
**PR #2 of the refinement sequence** (follows the [design direction audit](https://github.com/RadicalxChange/www/pull/233)). Additive, low-risk foundation only — **no surface repaint here.** Swapping the `bg-golden-fizz` full-page screens to white is a big, page-by-page visual diff and gets its own PR so reviewers can see it in isolation.

Draft, for review.

## What's in it

### 1. Light-surface / dark-mode fix (the high-value one)
`global.css` now sets `color-scheme: light` and a white `<body>` background. Previously `<body>` had no background or text color, so any page that doesn't paint its own surface (Updates, every article, Search, Wiki, Community lists) fell through to the browser's **dark** canvas for OS-dark-mode visitors → **black text on a near-black background.**

Set on **low-specificity** selectors (`:root`, `body`), so any Tailwind utility on a page wrapper or section (`bg-black`, `bg-golden-fizz`, a page's `bodyBg`) **still wins** — intentionally-dark or yellow bands are unaffected. Verified in-browser under emulated dark mode:
- Updates: now white surface, black text (was black-on-black).
- 404 (`bodyBg: bg-golden-fizz`): `<body>` still computes brand yellow `rgb(237,255,56)` — the default is overridable, as intended.

### 2. Locked brand palette (config level only)
`tailwind.config.js` colors reorganized into a **locked brand group** (`black`, `white`, `golden-fizz`) and a clearly-commented **restricted, non-brand** group:
- Removed single-use `light-gold` / `light-black`; their two usages swapped to brand `golden-fizz` / `black` (popup CTA, about press overlay — near-invisible changes).
- `.see-more-link` de-grayed → brand black at reduced opacity.
- **`gray` and `red` are quarantined, not deleted.** They're used for *functional* vote-bar data-viz on the Community Week NYC microsite; deleting them would break that page, which doesn't belong in a foundations PR. Commented as restricted and flagged for removal when CWNYC is redesigned. **→ Confirm you're happy with quarantine-vs-delete here.**

### 3. Spacing-rhythm tokens (additive scaffolding)
Documented `section` / `block` / `element` spacing tokens for consistent gaps between structural blocks (used by later component/template PRs, replacing ad-hoc `mb-16`/`mb-8`).

### 4. README documentation
Palette + contrast rule, surface/color-scheme note, the **type roles** table (one Messer weight → hierarchy by size; flags the Suisse Book-vs-Regular body drift), and the spacing scale.

## Constraints
Stays in 11ty + Nunjucks + Tailwind. No content/routes/redirects/i18n/Fathom/newsletter changes. `npm run build` passes.

## Next (separate PRs)
Reusable components (section header, content card, button pair, motifs) → global chrome → **surface repaint** (white + black-section moments) → homepage restructure → content templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)