### PR TITLE
[Specs — do not cascade yet] Component set: section header, canonical card, buttons, motifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,13 @@ white/yellow-on-black only — **never** yellow/white on yellow/white, and never
 yellow text on white.
 
 `gray` and `red` remain in the config but are **restricted, non-brand** colors kept
-only for functional data-viz on the Community Week NYC microsite. Don't use them on
-brand surfaces.
+only for functional data-viz on the Community Week NYC microsite (pass / disagree vote
+bars). **They are retained intentionally — please don't "tidy them up."** There the
+colors carry _meaning_ (data encoding), not decoration, so they're a different category
+from the brand surface and removing them would break the vote bars. The brand rule
+(black / white / yellow) governs brand surfaces; a data-viz legend is exempt. Revisit
+the encoding only if/when CWNYC gets a visual refresh on its own merits. Don't use them
+on brand surfaces, and don't introduce new usages.
 
 ### Surface & color scheme
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,41 @@ The RadicalxChange www site is built on [11ty](https://www.11ty.dev/). It's styl
 
 ## Design
 
+> A refinement effort is tightening the site's craft _within_ the existing brand
+> (hierarchy, spacing, component consistency, restraint). See `DESIGN_DIRECTION.md`
+> for the audit and plan. The tokens below are the shared foundation that work builds on.
+
+### Palette
+
+Three brand colors, nothing else:
+
+| Token            | Hex       | Role                                                         |
+| ---------------- | --------- | ----------------------------------------------------------- |
+| `black`          | `#000000` | Primary ink; black section bands ("the big moments").       |
+| `white`          | `#FFFFFF` | Default page surface.                                        |
+| `golden-fizz`    | `#EDFF38` | Brand **yellow** — punctuation only.                        |
+
+**Yellow is punctuation, not wallpaper.** Use it for accents (underlines, icon
+circles, highlight marks, number circles, a single key callout) and the rare,
+countable full-bleed jolt (newsletter, donate CTA, 404). Reach for **black
+sections** — not yellow fills — for big confident moments. Default surface is white.
+
+**Contrast rule (ADA), from the Brand Book:** black-on-yellow, black-on-white, or
+white/yellow-on-black only — **never** yellow/white on yellow/white, and never
+yellow text on white.
+
+`gray` and `red` remain in the config but are **restricted, non-brand** colors kept
+only for functional data-viz on the Community Week NYC microsite. Don't use them on
+brand surfaces.
+
+### Surface & color scheme
+
+`global.css` sets `color-scheme: light` and a white `body` background so no page can
+fall through to the browser's dark canvas (which previously made black text invisible
+in OS dark mode). These live on low-specificity selectors, so any utility
+(`bg-black`, `bg-golden-fizz`, a page's `bodyBg`) still overrides them — intentionally
+dark or yellow bands are unaffected.
+
 ### Grid
 
 Pages are laid out on grids. A grid has fixed-width margins, fixed-width gutters and fluid columns. Desktop pages are on a 12-column or 16-column grid. Mobile pages are on a 4-column grid.
@@ -48,11 +83,44 @@ We use TailWind's built-in scale for general size and space. These utilities use
 
 For typography heavy pages, we use a multiple of line height for vertical spacing. The utilities use `em` units.
 
+#### Section rhythm
+
+For the gaps **between** structural blocks, prefer the documented rhythm tokens over
+ad-hoc `mb-16` / `mb-8` one-offs, so every page shares one calm cadence:
+
+| Token     | Value                    | Use                                   |
+| --------- | ------------------------ | ------------------------------------- |
+| `section` | `clamp(4rem, 8vw, 8rem)` | Between major page sections.          |
+| `block`   | `clamp(2rem, 4vw, 3rem)` | Between blocks within a section.      |
+| `element` | `1.5rem`                 | Between elements within a block.      |
+
+Apply as any Tailwind spacing utility, e.g. `mb-section`, `space-y-block`, `py-section`,
+`gap-element`.
+
 ### Typography
 
 We use a [fluid type scale](https://utopia.fyi/blog/designing-with-fluid-type-scales) for almost all text. This scale provides a base text size and "steps" up and down from that. If you assign a step size to text, it will automatically scale relative to the width of the browser.
 
 For text written in Messer font, use font-size in the `vw` unit instead.
+
+#### Type roles
+
+Two families, a small set of roles. **Only one Messer weight is licensed for web**
+(`MesserV2.0-Condensed`, 400) — so display hierarchy comes from **size, not weight**.
+Keep to these roles rather than inventing per-page sizes:
+
+| Role                | Font (`font-…`)        | Treatment                                   | Notes                                            |
+| ------------------- | ---------------------- | ------------------------------------------- | ------------------------------------------------ |
+| Display / page title | `display` (Messer)     | **ALL CAPS**, `size-lg/display`+            | One per page. Caps only — Messer is a caps face. |
+| Hero statement      | `display` (Messer caps) | short, oversized                            | Keep it short (≈4–8 words); long copy → standfirst. |
+| Section header      | `body` bold (Suisse)   | `size-2`, with a hairline rule beneath      | Pairs with the eyebrow below.                    |
+| Eyebrow / kicker    | `body` bold (Suisse)   | uppercase, `size--1`, letter-spaced, quiet  | A small label, **not** a headline.               |
+| Body                | `body` (Suisse)        | `size-0`                                    | Brand body face is Suisse Book.¹                 |
+| Meta (author/date/tag) | `body` (Suisse)     | `size--1`                                   | One consistent size for all metadata.            |
+
+¹ The Brand Book specifies **Suisse Int'l Book** for paragraph text; today `font-body`
+resolves to Suisse Int'l _Regular_. A small, deliberate drift to reconcile in a later
+typography pass — flagged, not silently changed.
 
 ## Code Layout
 

--- a/src/site/_includes/components/button.njk
+++ b/src/site/_includes/components/button.njk
@@ -1,0 +1,37 @@
+<!-- prettier-ignore -->
+{#
+  Buttons — two weights, one rhythm.
+
+  primary   — pill with sliding arrow. The page's main call to action.
+              (Matches the existing action-button so adoption is a rename.)
+  secondary — uppercase text + thick underline. For lower-priority actions
+              and "see all"-style links that aren't a section header.
+
+  Use at most one primary per view; reach for secondary otherwise.
+#}
+{% macro primary(href, label) %}
+<a
+  class="group inline-flex items-center justify-between py-2 px-4 xl:pl-6 xl:pr-4 border border-black rounded-oval text-size--1"
+  href="{{ href }}"
+>
+  <span class="text-center uppercase">{{ label }}</span>
+  <span
+    class="hidden xl:inline w-4 group-hover:w-12 transition-width duration-300 ease-out"
+  ></span>
+  <img
+    class="hidden xl:inline-block"
+    src="/images/ui/next-arrow.svg"
+    width="24"
+    height="18"
+    alt=""
+  />
+</a>
+{% endmacro %}
+
+{% macro secondary(href, label) %}
+<a
+  class="group inline-flex items-baseline gap-2 text-size--1 uppercase tracking-wide thick-link"
+  href="{{ href }}"
+  >{{ label }} <span aria-hidden="true">&rarr;</span></a
+>
+{% endmacro %}

--- a/src/site/_includes/components/content-card.njk
+++ b/src/site/_includes/components/content-card.njk
@@ -1,0 +1,43 @@
+<!-- prettier-ignore -->
+{#
+  Content card — the ONE canonical card, promoted from the (good) Updates
+  card and made uniform-height without the old min-height hack.
+
+  Structure: tag · title · optional description · meta (author / date),
+  pinned to the bottom so meta aligns across a row. The whole card is the
+  link. Drop it in any CSS grid; `h-full` + the grid's stretch makes every
+  card in a row equal height, and `mt-auto` keeps the meta on the baseline.
+
+  Args:
+    href        (required)
+    title       (required)
+    tag         (optional) — small uppercase label (e.g. "Blog Post", "Project")
+    description (optional) — short standfirst (used by Projects/Proposals cards)
+    meta1       (optional) — e.g. author
+    meta2       (optional) — e.g. date
+#}
+{% macro render(href, title, tag, description, meta1, meta2) %}
+<a
+  href="{{ href }}"
+  class="group flex flex-col h-full pt-element border-t border-black"
+>
+  <!-- prettier-ignore -->
+  {% if tag %}
+  <p class="mb-element text-size--1 uppercase tracking-wide opacity-60">
+    {{ tag }}
+  </p>
+  {% endif %}
+  <h3 class="text-size-2 leading-tight group-hover:thick-link">{{ title }}</h3>
+  <!-- prettier-ignore -->
+  {% if description %}
+  <p class="mt-element text-size--1 opacity-80">{{ description }}</p>
+  {% endif %}
+  <!-- prettier-ignore -->
+  {% if meta1 or meta2 %}
+  <div class="mt-auto pt-block text-size--1 opacity-60">
+    {% if meta1 %}<p>{{ meta1 }}</p>{% endif %}
+    {% if meta2 %}<p>{{ meta2 }}</p>{% endif %}
+  </div>
+  {% endif %}
+</a>
+{% endmacro %}

--- a/src/site/_includes/components/popup.njk
+++ b/src/site/_includes/components/popup.njk
@@ -38,7 +38,7 @@
             <div
               class="sticky bottom-0 left-0 lg:px-16 lg:rounded-tvinfo items-center"
             >
-              <button class="block bg-light-gold rounded-oval py-3 px-8 mx-auto mb-4 mt-12">
+              <button class="block bg-golden-fizz rounded-oval py-3 px-8 mx-auto mb-4 mt-12">
                 <a
                   class="text-black text-size--2 uppercase"
                   href="{{ link }}"

--- a/src/site/_includes/components/section-header.njk
+++ b/src/site/_includes/components/section-header.njk
@@ -1,0 +1,34 @@
+<!-- prettier-ignore -->
+{#
+  Section header — the shared "section header + rule + See all" motif.
+
+  Every listing and homepage section opens with this so the page has one
+  consistent rhythm instead of ad-hoc per-section headings.
+
+  Args:
+    title       (required) — section title, Suisse Bold
+    eyebrow     (optional) — small uppercase kicker above the title
+    seeAllHref  (optional) — if set, renders a right-aligned "See all →"
+    seeAllLabel (optional) — overrides the "See all" text
+#}
+{% macro render(title, eyebrow, seeAllHref, seeAllLabel) %}
+<div class="border-b border-black pb-element">
+  <!-- prettier-ignore -->
+  {% if eyebrow %}
+  <p class="mb-element text-size--1 font-bold uppercase tracking-wide">
+    {{ eyebrow }}
+  </p>
+  {% endif %}
+  <div class="flex items-baseline justify-between gap-element">
+    <h2 class="font-bold text-size-2">{{ title }}</h2>
+    <!-- prettier-ignore -->
+    {% if seeAllHref %}
+    <a
+      href="{{ seeAllHref }}"
+      class="shrink-0 text-size--1 uppercase tracking-wide thick-link"
+      >{{ seeAllLabel or "See all" }} &rarr;</a
+    >
+    {% endif %}
+  </div>
+</div>
+{% endmacro %}

--- a/src/site/_includes/css/components.css
+++ b/src/site/_includes/css/components.css
@@ -1,0 +1,54 @@
+/* Reusable component motifs.
+
+   This is where the brand YELLOW lives — as punctuation, not wallpaper.
+   Keep these small and composable; pages assemble them, they don't restyle
+   them. See README → Design, and the /styleguide page for live examples. */
+
+/* Yellow highlight behind a word or phrase (inline). Black-on-yellow = ADA-safe. */
+.mark-highlight {
+  background-color: theme("colors.golden-fizz");
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  padding: 0 0.12em;
+}
+
+/* Thick yellow underline sitting behind the text baseline. */
+.underline-yellow {
+  background-image: linear-gradient(
+    theme("colors.golden-fizz"),
+    theme("colors.golden-fizz")
+  );
+  background-repeat: no-repeat;
+  background-position: 0 88%;
+  background-size: 100% 0.32em;
+}
+
+/* Circle holding a glyph/icon — yellow fill, black mark (ADA-safe). */
+.icon-circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5em;
+  height: 2.5em;
+  border-radius: 9999px;
+  background-color: theme("colors.golden-fizz");
+  color: theme("colors.black");
+}
+
+/* Numbered step marker — outlined circle, used for ordered sequences. */
+.number-circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2em;
+  height: 2.2em;
+  border-radius: 9999px;
+  border: 2px solid theme("colors.black");
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+/* Inside a black band (.is-on-dark), flip the outlined motifs to read on black. */
+.is-on-dark .number-circle {
+  border-color: theme("colors.white");
+}

--- a/src/site/_includes/css/global.css
+++ b/src/site/_includes/css/global.css
@@ -1,3 +1,23 @@
+/* Lock the site to a light surface.
+
+   Without this, pages that don't paint their own background fall through to the
+   browser's default canvas — which is BLACK for visitors whose OS is in dark
+   mode, rendering black body text invisible (Updates, articles, Search, Wiki…).
+   `color-scheme: light` also keeps native controls and scrollbars light.
+
+   This is a DEFAULT, not an override: the background/color live on the low-
+   specificity `body` element selector, so any Tailwind utility on a page
+   wrapper or section (bg-black, bg-golden-fizz, text-white, or a page's
+   `bodyBg`) still wins. Intentionally-dark bands are unaffected. */
+:root {
+  color-scheme: light;
+}
+
 html {
   scroll-behavior: smooth;
+}
+
+body {
+  background-color: theme("colors.white");
+  color: theme("colors.black");
 }

--- a/src/site/_includes/css/link.css
+++ b/src/site/_includes/css/link.css
@@ -1,8 +1,10 @@
 .see-more-link {
-  @apply text-gray;
+  /* De-emphasized via opacity on brand black rather than an off-brand grey. */
+  color: theme("colors.black");
+  opacity: 0.6;
 
   &:hover {
-    @apply text-black;
+    opacity: 1;
   }
 }
 

--- a/src/site/_includes/css/styles.css
+++ b/src/site/_includes/css/styles.css
@@ -8,6 +8,7 @@
 @import "tailwindcss/components";
 
 /* Custom components */
+@import "./components.css";
 @import "./logo.css";
 @import "./menu.css";
 @import "./about.css";

--- a/src/site/about/index.njk
+++ b/src/site/about/index.njk
@@ -234,7 +234,7 @@ supporters:
         <p>{{ article.date | readableDate }}</p></a
       >
       <div
-        class="about_press-description z-10 absolute top-1/2 left-1/8 w-max p-2 bg-light-black text-white text-size--4"
+        class="about_press-description z-10 absolute top-1/2 left-1/8 w-max p-2 bg-black text-white text-size--4"
       >
         {{ article.title }}
       </div>

--- a/src/site/styleguide/index.njk
+++ b/src/site/styleguide/index.njk
@@ -17,6 +17,24 @@ eleventyExcludeFromCollections: true
 <!-- prettier-ignore -->
 {% import "components/button.njk" as button %}
 
+<!-- A/B comparison harness — styleguide-only overrides so the canonical
+     content-card macro stays the single source of truth. These classes do not
+     ship; they only let us compare variants side-by-side on real fonts. -->
+<style>
+  /* Title-weight variant B: Suisse Bold instead of the canonical regular. */
+  .ab-bold h3 {
+    font-weight: 700;
+  }
+  /* Rule-placement variant B: hairline under the meta (today's Updates idiom)
+     instead of the canonical top hairline over the tag. */
+  .ab-bottom-rule > a {
+    border-top: 0;
+    padding-top: 0;
+    border-bottom: 1px solid #000;
+    padding-bottom: 1.5rem;
+  }
+</style>
+
 <main class="mx-auto max-w-6xl px-xmargin lg:px-lg/xmargin py-block space-y-section">
   <!-- PAGE TITLE -->
   <header class="space-y-element">
@@ -137,6 +155,62 @@ eleventyExcludeFromCollections: true
       {{ card.render(href="#", tag="Project", title="Plural Voting in the Colorado Legislature", description="A first-in-the-nation experiment using quadratic voting to set budget priorities in a US state legislature.") }}
       {{ card.render(href="#", tag="Policy Proposal", title="Data Freedom Act", description="A model bill establishing data coalitions and fiduciary duties for the data economy.") }}
     </div>
+  </section>
+
+  <!-- A/B #1 — TITLE WEIGHT, judged as a full grid (the tiled effect is the decision) -->
+  <!-- prettier-ignore -->
+  {% set abCards = [
+    {tag:"Paper", title:"The Plural Stack: Rebuilding our Digital Foundations from Protocol Up", m1:"Andreas Fauler, et al", m2:"June 17, 2026"},
+    {tag:"Announcement", title:"Civic AI Launches at Oxford", m1:"RxC Team", m2:"March 31, 2026"},
+    {tag:"Blog Post", title:"Europe Doesn't Need Its Own Big Tech. It Needs Protocols Nobody Can Capture.", m1:"Andreas Fauler, Anja von Rosenstiel et al", m2:"June 17, 2026"},
+    {tag:"Podcast", title:"Takahiro Anno: Fixing Bugs in Democracy", m1:"Takahiro Anno, Jess Scully", m2:"November 11, 2025"},
+    {tag:"Announcement", title:"Germany Launches a Digital Democracy Lab", m1:"RxC Team", m2:"February 3, 2026"},
+    {tag:"Blog Post", title:"Reactive vs. Co-Creative Democracy", m1:"Martin Rausch, Tom Atlee, Jenna Büchy", m2:"April 29, 2026"},
+    {tag:"Announcement", title:"Co-Creative Democracy, From Taipei to NYC", m1:"RxC Team", m2:"May 5, 2026"},
+    {tag:"Podcast", title:"What Protests Want, With Yuting Jiang", m1:"Yuting Jiang, Jess Scully", m2:"November 26, 2025"}
+  ] %}
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="A/B #1 — Card title weight", eyebrow="Judge as a grid, not one card") }}
+    <p class="text-size--1 opacity-60 max-w-2xl">The decision hinges on the tiled effect, so both are rendered as full 8-card grids. Hypothesis: <strong>regular</strong> for density — bold can turn into a heavy, vibrating field when tiled.</p>
+
+    <p class="text-size--1 font-bold uppercase tracking-wide">A · Suisse regular (canonical / shipped)</p>
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-block gap-y-section">
+      <!-- prettier-ignore -->
+      {% for c in abCards %}{{ card.render(href="#", tag=c.tag, title=c.title, meta1=c.m1, meta2=c.m2) }}{% endfor %}
+    </div>
+
+    <p class="text-size--1 font-bold uppercase tracking-wide pt-block">B · Suisse bold</p>
+    <div class="ab-bold grid grid-cols-2 lg:grid-cols-4 gap-x-block gap-y-section">
+      <!-- prettier-ignore -->
+      {% for c in abCards %}{{ card.render(href="#", tag=c.tag, title=c.title, meta1=c.m1, meta2=c.m2) }}{% endfor %}
+    </div>
+  </section>
+
+  <!-- A/B #2 — RULE PLACEMENT, framed for rollout-consistency vs current bottom-rule -->
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="A/B #2 — Rule placement", eyebrow="Rollout consistency check") }}
+    <p class="text-size--1 opacity-60 max-w-2xl">Top hairline over the tag (the stronger system, matches the brand-book header-with-rule logic) vs the bottom rule used on Updates today — so we can see whether a mixed idiom mid-rollout reads as intentional or just transitional.</p>
+
+    <p class="text-size--1 font-bold uppercase tracking-wide">A · Top rule over tag (canonical / shipped)</p>
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-block gap-y-block">
+      <!-- prettier-ignore -->
+      {% for c in abCards %}{% if loop.index <= 4 %}{{ card.render(href="#", tag=c.tag, title=c.title, meta1=c.m1, meta2=c.m2) }}{% endif %}{% endfor %}
+    </div>
+
+    <p class="text-size--1 font-bold uppercase tracking-wide pt-block">B · Bottom rule under meta (today's Updates idiom)</p>
+    <div class="ab-bottom-rule grid grid-cols-2 lg:grid-cols-4 gap-x-block gap-y-block">
+      <!-- prettier-ignore -->
+      {% for c in abCards %}{% if loop.index <= 4 %}{{ card.render(href="#", tag=c.tag, title=c.title, meta1=c.m1, meta2=c.m2) }}{% endif %}{% endfor %}
+    </div>
+  </section>
+
+  <!-- Resolved decisions (no A/B needed) -->
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="Resolved", eyebrow="Locked, for the record") }}
+    <ul class="space-y-element text-size-0 max-w-2xl list-disc pl-6">
+      <li><strong>Tag / meta opacity — locked at 60%.</strong> Effective <code>#666</code> on white = <strong>5.74:1</strong>, passes WCAG AA for normal text (4.5:1). Description at 80% = 12.6:1.</li>
+      <li><strong>Eyebrow — optional, used only where it earns it.</strong> Standard-on-every-section would just re-create the stacked-label noise from audit finding&nbsp;#2.</li>
+    </ul>
   </section>
 
   <!-- BLACK SECTION moment — the "sandwich" confidence move; yellow as accent within -->

--- a/src/site/styleguide/index.njk
+++ b/src/site/styleguide/index.njk
@@ -1,0 +1,173 @@
+---
+layout: layouts/_base.njk
+title: Component Styleguide
+permalink: /styleguide/index.html
+eleventyExcludeFromCollections: true
+---
+
+<!-- prettier-ignore -->
+{% block otherHead %}
+<meta name="robots" content="noindex, nofollow" />
+{% endblock %}
+
+<!-- prettier-ignore -->
+{% import "components/section-header.njk" as sectionHeader %}
+<!-- prettier-ignore -->
+{% import "components/content-card.njk" as card %}
+<!-- prettier-ignore -->
+{% import "components/button.njk" as button %}
+
+<main class="mx-auto max-w-6xl px-xmargin lg:px-lg/xmargin py-block space-y-section">
+  <!-- PAGE TITLE -->
+  <header class="space-y-element">
+    <p class="text-size--1 font-bold uppercase tracking-wide">
+      RxC · Component Styleguide
+    </p>
+    <h1 class="font-display uppercase text-size-xl/display leading-none">
+      Pixels, not prose
+    </h1>
+    <p class="text-size-0 max-w-2xl">
+      Live render of the proposed PR&nbsp;#3 components on real brand fonts and
+      tokens. This page is <strong>noindex</strong> and not linked in nav — a
+      working reference, not a public page. Nothing here is applied to existing
+      templates yet.
+    </p>
+  </header>
+
+  <!-- TYPE ROLES -->
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="Type roles", eyebrow="Foundations") }}
+    <div class="space-y-block">
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Display / page title — Messer, ALL CAPS</p>
+        <p class="font-display uppercase text-size-lg/display leading-none">Plurality at the wheel</p>
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Section header — Suisse Bold</p>
+        <p class="font-bold text-size-2">Projects &amp; policy proposals</p>
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Eyebrow / kicker — Suisse Bold uppercase, tracked</p>
+        <p class="font-bold text-size--1 uppercase tracking-wide">From the field</p>
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Body — Suisse, size-0</p>
+        <p class="text-size-0 max-w-2xl">RadicalxChange advances participatory governance for the age of AI — keeping human agency and democratic participation at the wheel, and treating technology as a means of cooperating across difference.</p>
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Meta — size--1</p>
+        <p class="text-size--1 opacity-60">RxC Team · June 17, 2026</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- BUTTONS -->
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="Buttons", eyebrow="Two weights, one rhythm") }}
+    <div class="flex flex-wrap items-center gap-block">
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Primary</p>
+        {{ button.primary(href="#", label="Explore the Plural Stack") }}
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Secondary</p>
+        {{ button.secondary(href="#", label="Read the paper") }}
+      </div>
+    </div>
+  </section>
+
+  <!-- MOTIFS — where yellow lives -->
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="Motifs", eyebrow="Where the yellow lives") }}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-block items-start">
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Highlight mark</p>
+        <p class="text-size-1">Helping <span class="mark-highlight">humans, not algorithms</span>, steer the AI transition.</p>
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Yellow underline</p>
+        <p class="text-size-1">A philosophy called <span class="underline-yellow">Plurality</span>.</p>
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Icon circle</p>
+        <span class="icon-circle text-size-1 font-bold">&rarr;</span>
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Number circle</p>
+        <div class="flex gap-element">
+          <span class="number-circle text-size--1">1</span>
+          <span class="number-circle text-size--1">2</span>
+          <span class="number-circle text-size--1">3</span>
+        </div>
+      </div>
+      <div class="space-y-element">
+        <p class="text-size--1 opacity-60 uppercase tracking-wide">Stat callout</p>
+        <div class="border border-black p-element max-w-xs">
+          <p class="font-display text-size-xl/display leading-none">11</p>
+          <p class="font-bold uppercase text-size--1 mt-element">parliamentary seats won by Japan's Team Mirai in 2026</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SECTION HEADER component -->
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="Section header", eyebrow="With eyebrow + See all") }}
+    <div class="space-y-block">
+      <p class="text-size--1 opacity-60">Default — title + rule:</p>
+      {{ sectionHeader.render(title="Updates") }}
+      <p class="text-size--1 opacity-60 pt-block">With eyebrow + “See all →”:</p>
+      {{ sectionHeader.render(title="Latest updates", eyebrow="From the field", seeAllHref="/updates", seeAllLabel="See all") }}
+    </div>
+  </section>
+
+  <!-- CONTENT CARD grid — varied lengths prove uniform height + bottom-aligned meta -->
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="Content card", eyebrow="The canonical card", seeAllHref="/updates", seeAllLabel="See all") }}
+    <p class="text-size--1 opacity-60 max-w-2xl">Deliberately mixed title lengths — note the meta row stays bottom-aligned across the row, with no forced empty gaps (the old card padded short titles with a min-height hack).</p>
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-block gap-y-section">
+      {{ card.render(href="#", tag="Paper", title="The Plural Stack: Rebuilding our Digital Foundations from Protocol Up", meta1="Andreas Fauler, et al", meta2="June 17, 2026") }}
+      {{ card.render(href="#", tag="Announcement", title="Civic AI Launches at Oxford", meta1="RxC Team", meta2="March 31, 2026") }}
+      {{ card.render(href="#", tag="Blog Post", title="Europe Doesn't Need Its Own Big Tech. It Needs Protocols Nobody Can Capture.", meta1="Andreas Fauler, Anja von Rosenstiel et al", meta2="June 17, 2026") }}
+      {{ card.render(href="#", tag="Podcast", title="Takahiro Anno: Fixing Bugs in Democracy", meta1="Takahiro Anno, Jess Scully", meta2="November 11, 2025") }}
+    </div>
+
+    <p class="text-size--1 opacity-60 max-w-2xl pt-block">Same card, with a short description (Projects / Proposals use this variant):</p>
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-block gap-y-block">
+      {{ card.render(href="#", tag="Project", title="Plural Voting in the Colorado Legislature", description="A first-in-the-nation experiment using quadratic voting to set budget priorities in a US state legislature.") }}
+      {{ card.render(href="#", tag="Policy Proposal", title="Data Freedom Act", description="A model bill establishing data coalitions and fiduciary duties for the data economy.") }}
+    </div>
+  </section>
+
+  <!-- BLACK SECTION moment — the "sandwich" confidence move; yellow as accent within -->
+  <section class="space-y-block">
+    {{ sectionHeader.render(title="Black-section moment", eyebrow="Big gestures use black, not yellow fills") }}
+  </section>
+</main>
+
+<!-- Full-bleed black band lives outside the padded container -->
+<section class="is-on-dark bg-black text-white">
+  <div class="mx-auto max-w-6xl px-xmargin lg:px-lg/xmargin py-section space-y-block">
+    <p class="text-size--1 font-bold uppercase tracking-wide">The Plural Stack</p>
+    <p class="font-display uppercase text-size-lg/display leading-none max-w-4xl">
+      Technology for <span class="mark-highlight text-black">cooperation</span> across difference
+    </p>
+    <p class="text-size-0 max-w-2xl">
+      Black carries the confident moments — hero bands, dividers, the footer. Yellow stays an
+      accent <span class="mark-highlight">inside</span> them, so the big gestures don't spend the
+      one accent color.
+    </p>
+    <div class="flex flex-wrap gap-element items-center pt-element">
+      <a class="group inline-flex items-center justify-between py-2 px-4 xl:pl-6 xl:pr-4 border border-white rounded-oval text-size--1" href="#">
+        <span class="text-center uppercase">Explore the stack</span>
+      </a>
+      <span class="number-circle text-size--1">1</span>
+      <span class="number-circle text-size--1">2</span>
+      <span class="number-circle text-size--1">3</span>
+    </div>
+  </div>
+</section>
+
+<div class="mx-auto max-w-6xl px-xmargin lg:px-lg/xmargin py-section">
+  <p class="text-size--1 opacity-60">End of styleguide.</p>
+</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,15 +39,25 @@ module.exports = {
       body: ["Suisse Intl", "sans-serif"],
     },
     colors: {
-      "golden-fizz": "#EDFF38",
-      "light-gold": "#FAFFC3",
-      red: "#C53030",
+      // ---- Brand palette (locked) — the only colors for brand surfaces ----
+      // Per the RxC Brand Book: black + white + yellow, nothing else. Yellow is
+      // punctuation (marks, underlines, icon circles, one callout), never
+      // wallpaper. Contrast rule (ADA): black-on-yellow, black-on-white, or
+      // white/yellow-on-black only — never yellow/white on yellow/white.
       black: "#000000",
-      "light-black": "#010101",
       white: "#FFFFFF",
-      gray: "#6C6C6C",
+      "golden-fizz": "#EDFF38", // brand yellow
+
       transparent: "transparent",
       current: "currentColor",
+
+      // ---- Restricted (non-brand) — do NOT use on brand surfaces ----
+      // Retained only for functional data-visualization on the Community Week
+      // NYC microsite (pass / disagree vote bars). Not part of the brand
+      // system and slated for removal when that page is redesigned. Do not
+      // introduce new usages — reach for the brand palette above instead.
+      gray: "#6C6C6C",
+      red: "#C53030",
     },
     extend: {
       borderRadius: {
@@ -85,6 +95,13 @@ module.exports = {
       },
       height: { 36: "9rem" },
       spacing: {
+        // Section rhythm — documented vertical-spacing scale (see README →
+        // Design → Spacing). Use these for the gaps BETWEEN structural blocks
+        // (e.g. mb-section, space-y-block, py-section) instead of ad-hoc
+        // mb-16 / mb-8 one-offs, so pages share one calm, consistent rhythm.
+        section: "clamp(4rem, 8vw, 8rem)", // between major page sections
+        block: "clamp(2rem, 4vw, 3rem)", // between blocks within a section
+        element: "1.5rem", // between elements within a block
         margin: "1rem",
         "lg/margin": "1.5rem",
         ymargin: "1rem",


### PR DESCRIPTION
**PR #3 of the refinement sequence — review the pixels, please don't merge into the cascade yet.** This is the reusable component set that every downstream PR (#5 homepage, #6 templates) inherits, so per our plan it gets eyes *before* anything adopts it. If the card/section-header spec is even slightly off, the mistake compounds across the sequence.

Stacked on the foundations branch ([#234](https://github.com/RadicalxChange/www/pull/234)) — base is set to `design/foundations-tokens` so this diff shows only the component files. Nothing here is applied to any existing template.

## How to review
Build the site and open **`/styleguide/`** (noindex, not nav-linked) — it renders every component on real brand fonts and tokens, including the mixed-length card grid and the black-section moment. (I've shared rendered desktop + mobile screenshots with Jack directly in review.)

## What's proposed
- **Section header** (`section-header.njk`) — the shared `eyebrow + title + rule + See all →` motif. One rhythm for every listing/section.
- **Canonical content card** (`content-card.njk`) — promoted from the (good) Updates card. **Key fix:** the old card forced a `min-height` on the title, which left big empty gaps under short titles. New card is `flex h-full` with the meta pinned via `mt-auto`, so meta bottom-aligns across a row at *any* title length, no padding hacks. Optional `description` for the Projects/Proposals variant.
- **Buttons** (`button.njk`) — `primary` (pill + sliding arrow, identical to the existing `action-button`, so adoption is a rename) and `secondary` (uppercase text + thick underline).
- **Motifs** (`components.css`) — where the brand **yellow** lives: `mark-highlight`, `underline-yellow`, `icon-circle`, `number-circle`. Outlined motifs auto-flip to white inside `.is-on-dark` bands.
- **Black-section "moment"** demo in the styleguide — shows the white-surface / black-for-big-moments / yellow-as-accent discipline you described (oversized Messer caps in white, yellow only as an accent *within* the black).

## Specific things I'd value a call on (pixels)
1. **Card title weight** — currently Suisse **regular** at `size-2` (editorial/AI-Now restraint, matches today's Updates). Bolder (Suisse Bold) reads more "confident" but heavier across a 4-up grid. Which do you want as canonical?
2. **Card rule placement** — I used a **top** hairline over the tag (clear "item starts here"). The current Updates rule is on the bottom. Preference?
3. **Tag treatment** — uppercase, tracked, 60% opacity. Quiet enough / too quiet?
4. **Section-header eyebrow** — keep it optional (only where it adds meaning), or standard on every section?

Once the card is signed off, the rest of the sequence (chrome → repaint → homepage → templates) adopts it and moves faster.

## Constraints
11ty + Nunjucks + Tailwind only. No content/routes/redirects/i18n/Fathom/newsletter changes. `npm run build` passes. Verified desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
