### PR TITLE
Move Can AI See Me post from blog to announcements

### DIFF
--- a/src/site/_redirects
+++ b/src/site/_redirects
@@ -1,5 +1,8 @@
 /events/2024-berlin/ /events/2025-berlin/
 
+# Can AI See Me post moved from blog to announcements
+/updates/blog/can-ai-see-me /updates/announcements/2026-07-can-ai-see-me
+
 # Short URL for the Community Week NYC × RxC landing page (placards/print)
 /cwnyc /communityweeknyc/
 

--- a/src/site/updates/announcements/2026-07-02_can-ai-see-me.md
+++ b/src/site/updates/announcements/2026-07-02_can-ai-see-me.md
@@ -1,10 +1,9 @@
 ---
-layout: "layouts/blog-post.njk"
-slug: "can-ai-see-me"
+layout: "layouts/announcement.njk"
+slug: "2026-07-can-ai-see-me"
 date: "2026-07-02"
 title: "Can AI See Me? The case for plural AI heads to the UN's Global Dialogue"
 postHeader: "Can AI See Me? The case for plural AI heads to the UN's Global Dialogue"
-postAuthor: "RadicalxChange"
 ---
 
 Three weeks ago, RadicalxChange founder E. Glen Weyl [argued in The Economist](https://www.economist.com/by-invitation/2026/06/11/silicon-valley-needs-to-get-god) that AI will only serve humanity well if the people building it engage the world's faiths and cultures as partners, designing technology that strengthens diverse communities instead of imposing one worldview on everyone.


### PR DESCRIPTION
## Summary

Moves the live "Can AI See Me?" post (merged in #238, then edited on main) from the blog to announcements, keeping all post-merge content edits intact.

- New URL: `/updates/announcements/2026-07-can-ai-see-me/`
- Frontmatter updated to announcement conventions: `layouts/announcement.njk`, `YYYY-MM-`-prefixed slug, `postAuthor` removed
- Added a `_redirects` entry so the live `/updates/blog/can-ai-see-me` URL 301s to the new location
- Verified: build passes, new page renders with the updated title, old blog path is gone from `dist`, post appears in the announcements feed and no longer in the blog feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)