### PR TITLE
Embed the session recording on /geneva-reflections

### DIFF
--- a/site-data/content.json
+++ b/site-data/content.json
@@ -21,6 +21,13 @@
     "continents_display": "4+",
     "anonymity_note": "Pol.is deliberation is anonymous by design: statements are published verbatim with no names attached, and no vote can be traced to a person."
   },
+  "video": {
+    "youtube_id": "Rj419GhtAG4",
+    "url": "https://youtu.be/Rj419GhtAG4",
+    "title": "Watch the session recording",
+    "caption": "Lived-experience testimony from faith leaders in the UK, Singapore, and the US, then the live deliberation behind the results below.",
+    "privacy_note": "Plays in YouTube's privacy-enhanced mode; nothing loads from YouTube until you press play."
+  },
   "consensus": {
     "title": "The common ground",
     "intro": "Across every opinion group in the room, six demands drew broad agreement. Each theme below is grounded in specific statements — expand one to see the participants' own words and the full tallies behind it.",

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -85,6 +85,49 @@
   color: #6c6c6c;
 }
 
+/* ---- session recording ----------------------------------------------- */
+
+.geneva .gr-video {
+  aspect-ratio: 16 / 9;
+  background: #1a1a1a;
+}
+.geneva .gr-video iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+.geneva .gr-video-facade {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  color: #fff;
+  text-decoration: none;
+}
+.geneva .gr-video-play {
+  display: block;
+  width: 0;
+  height: 0;
+  border-left: 2.2rem solid #fff;
+  border-top: 1.3rem solid transparent;
+  border-bottom: 1.3rem solid transparent;
+  transition: transform 0.15s ease;
+}
+.geneva .gr-video-facade:hover .gr-video-play,
+.geneva .gr-video-facade:focus-visible .gr-video-play {
+  transform: scale(1.12);
+}
+.geneva .gr-video-label {
+  font-family: Messer, sans-serif;
+  font-size: var(--step-1);
+  text-transform: uppercase;
+  text-align: center;
+  padding: 0 1rem;
+}
+
 /* ---- vote bars ------------------------------------------------------ */
 
 .geneva .gr-stack {

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -173,6 +173,21 @@ description: "What would AI governance need to do so that everyone felt seen by 
     </div>
   </section>
 
+  {# ---------- session recording ---------- #}
+  {% if C.video %}
+  <section id="recording" aria-label="Session recording" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-3 lg:col-end-gutter-11">
+      <div class="gr-video" data-youtube-id="{{ C.video.youtube_id }}">
+        <a class="gr-video-facade" href="{{ C.video.url }}">
+          <span class="gr-video-play" aria-hidden="true"></span>
+          <span class="gr-video-label">{{ C.video.title }}</span>
+        </a>
+      </div>
+      <p class="gr-counts mt-2">{{ C.video.caption }} {{ C.video.privacy_note }}</p>
+    </div>
+  </section>
+  {% endif %}
+
   {# ---------- 3. common ground ---------- #}
   <section id="common-ground" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-4 mb-4 lg:mb-0">

--- a/src/site/js/geneva-reflections.js
+++ b/src/site/js/geneva-reflections.js
@@ -6,6 +6,30 @@
 (function () {
   "use strict";
 
+  // Session recording: click-to-load YouTube embed. Until the visitor
+  // presses play, nothing is requested from YouTube (the facade is plain
+  // HTML/CSS); without JS the facade is a normal link to the video.
+  var video = document.querySelector(".gr-video[data-youtube-id]");
+  if (video) {
+    var facade = video.querySelector(".gr-video-facade");
+    facade.addEventListener("click", function (e) {
+      e.preventDefault();
+      var iframe = document.createElement("iframe");
+      iframe.src =
+        "https://www.youtube-nocookie.com/embed/" +
+        encodeURIComponent(video.getAttribute("data-youtube-id")) +
+        "?autoplay=1";
+      iframe.title = "Session recording (YouTube)";
+      iframe.setAttribute(
+        "allow",
+        "autoplay; encrypted-media; picture-in-picture"
+      );
+      iframe.setAttribute("allowfullscreen", "");
+      video.replaceChild(iframe, facade);
+      iframe.focus();
+    });
+  }
+
   var table = document.getElementById("gr-explorer-table");
   var filters = document.getElementById("gr-filters");
   if (!table || !filters) return;


### PR DESCRIPTION
Follow-up to #240: embeds the now-published session recording (https://youtu.be/Rj419GhtAG4) on the results page, directly between the participation stats bar and "The common ground".

Implementation keeps the page's no-tracking promise:

- On load it's a pure HTML/CSS facade (no request to YouTube at all — verified via the network log)
- Pressing play swaps in YouTube's privacy-enhanced `youtube-nocookie.com` embed
- With JavaScript disabled, the facade is a plain link to the video on YouTube
- Video config lives in `site-data/content.json` (`video` block), so the ID can be swapped without touching templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)