### PR TITLE
Geneva Reflections: tiered restructure of the results page

### DIFF
--- a/scripts/analyze.py
+++ b/scripts/analyze.py
@@ -48,6 +48,11 @@ import sys
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join(ROOT, "data")
 OUT_PATH = os.path.join(ROOT, "site-data", "results.json")
+# Public statement-level CSV (aggregate tallies only — never participant
+# rows), served as the download link on the results pages. src/site/files is
+# passthrough-copied by Eleventy.
+CSV_PATH = os.path.join(ROOT, "src", "site", "files",
+                        "geneva-reflections-statements.csv")
 
 JUNK_IDS = {22, 72, 75}          # "Agree", "Xxxx", "Not enough time, sorry"
 SEED_MAX_ID = 19                 # statements 0-19 are facilitator seeds
@@ -215,8 +220,29 @@ def main():
         json.dump(results, f, indent=2, ensure_ascii=False)
         f.write("\n")
 
+    group_letters = sorted(group_sizes)
+    with open(CSV_PATH, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        header = ["statement_id", "statement", "source", "non_substantive",
+                  "votes", "agrees", "disagrees", "passes"]
+        for g in group_letters:
+            header += [f"group_{g}_votes", f"group_{g}_agrees",
+                       f"group_{g}_disagrees", f"group_{g}_passes"]
+        w.writerow(header)
+        for sid in stmt_ids:
+            s = statements[str(sid)]
+            row = [s["id"], s["text"], s["source"],
+                   "yes" if s["junk"] else "no",
+                   s["total"]["votes"], s["total"]["agrees"],
+                   s["total"]["disagrees"], s["total"]["passes"]]
+            for g in group_letters:
+                t = s["groups"][g]
+                row += [t["votes"], t["agrees"], t["disagrees"], t["passes"]]
+            w.writerow(row)
+
     p = results["participation"]
     print(f"wrote {os.path.relpath(OUT_PATH, ROOT)}")
+    print(f"wrote {os.path.relpath(CSV_PATH, ROOT)}")
     print(f"  participants {p['participants']} | votes {p['total_votes']} | "
           f"statements {p['total_statements']} ({p['live_statements']} live) | "
           f"groups {p['group_sizes']} + {p['unclustered']} unclustered")

--- a/site-data/content.json
+++ b/site-data/content.json
@@ -28,34 +28,40 @@
     "caption": "Lived-experience testimony from faith leaders in the UK, Singapore, and the US, then the live deliberation behind the results below.",
     "privacy_note": "Plays in YouTube's privacy-enhanced mode; nothing loads from YouTube until you press play."
   },
+  "legend_note": "◔ = thin data: fewer than 5 votes cast in that group; treat as directional.",
   "consensus": {
-    "title": "The common ground",
-    "intro": "Across every opinion group in the room, six demands drew broad agreement. Each theme below is grounded in specific statements — expand one to see the participants' own words and the full tallies behind it.",
+    "title": "What the room agreed on",
+    "intro": "Across every opinion group, six demands drew broad agreement. Each is shown with one statement in participants' own words — expand a theme for its supporting statements and each group's numbers.",
     "themes": [
       {
         "title": "Contestability & accountability",
         "blurb": "Communities must be able to challenge and correct how AI represents them; whoever sets an AI system's values must answer to the people affected — through regulation with teeth.",
-        "statements": [2, 10, 21]
+        "exemplar": 2,
+        "supporting": [10, 21]
       },
       {
         "title": "Protection from dependency & manipulation",
         "blurb": "Design AI against emotional over-dependence and manipulation — protections the whole room wanted as defaults, not options.",
-        "statements": [16, 7, 5, 51]
+        "exemplar": 16,
+        "supporting": [7, 5, 51]
       },
       {
         "title": "Human-reserved ground",
         "blurb": "Some questions — and, above all, care itself — must stay human. AI can support, but never substitute.",
-        "statements": [13, 53, 68, 14]
+        "exemplar": 68,
+        "supporting": [53, 13, 14]
       },
       {
         "title": "Data, consent & surveillance",
         "blurb": "Strict limits on who sees what people confide to AI, and a shared alarm about AI-enabled surveillance.",
-        "statements": [65, 67, 25, 6]
+        "exemplar": 65,
+        "supporting": [67, 25, 6]
       },
       {
         "title": "Community authorship",
         "blurb": "Communities should be able to build and shape AI on their own values, with each member seeing their own data first.",
-        "statements": [3, 17, 15],
+        "exemplar": 17,
+        "supporting": [3, 15],
         "cross_refs": [
           { "id": 6, "label": "See also the consent duty participants set for community-built AI — statement [6], under Data, consent & surveillance" }
         ]
@@ -63,7 +69,8 @@
       {
         "title": "Value transparency & epistemic care",
         "blurb": "Disclose whose values an AI carries, and take care with how knowledge — including faith traditions passed between generations — is transmitted.",
-        "statements": [47, 48, 62, 19, 74]
+        "exemplar": 47,
+        "supporting": [48, 62, 19]
       }
     ]
   },
@@ -75,66 +82,76 @@
         "key": "A",
         "name": "Boundary Keepers",
         "sketch": "Locates the remedy in limits on AI's reach: it isn't AI's job to reflect every culture's values [9]; some questions should only ever be answered by a person [13]; they do not want to feel “seen” by AI [23] and are drawn to statements of loss — the friend who talks more to AI than to them [30], AI as “junk food” [55]. The room's heavy passers: their abstentions cluster on statements about lived experience of misrepresentation, reading as distance from the experience rather than opposition to the agenda.",
-        "signature_statements": [9, 13, 23, 30]
+        "cards": [],
+        "references": [9, 13, 23, 30, 55]
       },
       {
         "key": "B",
         "name": "Hands-On Optimists",
         "sketch": "The only group at ease with AI in intimate territory — unanimous that AI has a role in spirituality [33 rejected 0/5], open to AI as moral interlocutor [12] and to the personalization trade-off [4] — yet the strongest voices for building AI bottom-up [24] and for governance reform [11], [20]. Remedy: agency through building and using. (Fewest votes cast per member; their tallies on late statements are thin.)",
-        "signature_statements": [33, 4, 24, 11]
+        "cards": [24, 11],
+        "references": [33, 4, 12, 20]
       },
       {
         "key": "C",
         "name": "Recognition Seekers",
-        "sketch": "Defined by the experience of misrecognition — “AI talks about my faith or culture like an outsider describing it” [0] — and the demand that this is AI's problem to fix (sharpest rejection in the event: [9] at 1/11/2). Wants recognition without capture: near-unanimous against manipulation [5], against moral outsourcing [12] and the privacy trade-off [4], while the most enthusiastic group for community-built AI [15], [3].",
-        "signature_statements": [0, 9, 5, 15]
+        "sketch": "Defined by the experience of misrecognition — “AI talks about my faith or culture like an outsider describing it” [0] — and the demand that this is AI's problem to fix (the sharpest rejection in the event: [9]). Wants recognition without capture: near-unanimous against manipulation [5], against moral outsourcing [12] and the privacy trade-off [4], while the most enthusiastic group for community-built AI [15], [3].",
+        "cards": [0],
+        "references": [9, 5, 15, 3]
       }
     ],
     "disclosure": "A fourth cluster, Group D, contains a single participant and cannot be characterized without identifying them; their votes count in the room-wide totals but not in group-level analysis. Two participants voted too few times to be clustered at all. Group A includes the facilitation account used to seed the first twenty statements; it cast only pass votes."
   },
-  "divides": {
-    "title": "The divides that cross the groups",
-    "intro": "A standard opinion report stops at what separates the groups. The more interesting findings run the other way: questions that split groups from within, and agreements that join groups usually opposed. This is what bridging analysis is for.",
+  "split": {
+    "title": "Where it genuinely split",
+    "lead": "“It isn't AI's job to reflect every culture's values” is the room's cleanest divide: the Boundary Keepers' most-agreed position and the Recognition Seekers' sharpest rejection. Universality versus representation is a real disagreement, not a misunderstanding — and it survives into the draft principles below.",
+    "statement": 9,
+    "expander_title": "More on the divides",
+    "resolved": {
+      "title": "A tension the room resolved",
+      "blurb": "Personalization versus protection looked like a dilemma — until the votes came in. The claim that AI knowing you personally is worth the privacy cost [4] was rejected by every group but one, while anti-dependency design came as close to consensus as anything in the event, including among the personalization-friendly group. The room wants AI that understands without a licence to capture.",
+      "statement": 4,
+      "cross_refs": [
+        { "id": 16, "label": "The anti-dependency statement [16] sits under Protection from dependency & manipulation above" }
+      ]
+    }
+  },
+  "surprise": {
+    "kicker": "The finding a standard poll would miss",
+    "title": "The surprise",
+    "intro": "A standard opinion report stops at what separates the groups. The most consequential findings here run the other way: an agreement that joins the two groups most opposed elsewhere, and a question that splits groups from within. This is what bridging analysis is for — and it is the method's case for the quadratic vote that follows.",
+    "bedfellows": {
+      "title": "Strange bedfellows",
+      "caption": "The two groups most opposed on whether AI should reflect every culture's values agree completely on something else: they do not want AI to know them intimately. Six members of one and ten of the other affirmed “I don't want to feel seen by AI” — against the one group that welcomes that closeness. Bridging analysis exists to find agreements like this: consensus that crosses the room's main divide from an unexpected direction.",
+      "statements": [23, 30, 55],
+      "cross_ref_note": "The same two groups sit at opposite poles of the divide above — Boundary Keepers embracing, Recognition Seekers rejecting, statement [9] — and of Group C's defining experience, statement [0]."
+    },
     "inner_life": {
       "title": "The question that splits every group",
       "caption": "Whether AI belongs in the inner and spiritual life — as a deepener of tradition, a moral interlocutor, or not at all — split two of the three groups down the middle. This tension runs through communities, not between them, and it is exactly the kind of question the next stage (quadratic voting) is designed to weigh.",
       "statements": [1, 12, 33, 43]
-    },
-    "bedfellows": {
-      "title": "Strange bedfellows",
-      "caption": "The two groups most opposed on whether AI should reflect every culture's values agree completely on something else: they do not want AI to know them intimately. Six members of one and ten of the other affirmed “I don't want to feel seen by AI” — against the one group that welcomes that closeness. Bridging analysis exists to find agreements like this: consensus that crosses the room's main divide from an unexpected direction.",
-      "opposed_statements": [9, 0],
-      "converge_statements": [23, 30, 55]
     }
   },
-  "disagreements": {
-    "title": "Where the room genuinely disagrees",
+  "notes": {
+    "title": "Reading these numbers",
     "items": [
       {
-        "title": "Whose values should AI reflect?",
-        "blurb": "“It isn't AI's job to reflect every culture's values” [9] is the room's cleanest divide: the Boundary Keepers' most-agreed position and the Recognition Seekers' sharpest rejection. Universality versus representation is a real disagreement, not a misunderstanding — and it survives into the draft principles below.",
-        "statements": [9]
-      },
-      {
-        "title": "A tension the room resolved",
-        "blurb": "Personalization versus protection looked like a dilemma — until the votes came in. The claim that AI knowing you personally is worth the privacy cost [4] was rejected by every group but one, while anti-dependency design [16] came as close to consensus as anything in the event, including among the personalization-friendly group. The room wants AI that understands without a licence to capture.",
-        "statements": [4, 16]
-      },
-      {
         "title": "What the passes mean",
-        "blurb": "Roughly a third of all votes were passes, clustering on statements about lived experience of misrepresentation. A pass is abstention, not opposition — often “this isn't my experience to judge.” We read heavy passing as epistemic humility inside the room, and flag it rather than hide it.",
-        "statements": []
+        "text": "Roughly a third of all votes were passes, clustering on statements about lived experience of misrepresentation. A pass is abstention, not opposition — often “this isn't my experience to judge.” We read heavy passing as epistemic humility inside the room, and flag it rather than hide it."
+      },
+      {
+        "title": "Honest limits",
+        "text": "Thirty-eight participants cast 2,201 votes on 83 statements; the smallest opinion group is a single person, some per-group counts on late statements rest on 2–6 votes, and one changed mind would change those stories. Agree/disagree/pass cannot distinguish 'I disagree' from 'not like this' — systematic passing on lived-experience statements is meaning the format flattens. And a synchronous, English-language, self-selected virtual event under-represents people without connectivity, non-English speakers (a participant said so from inside the room), and those most skeptical of AI-mediated deliberation, who by definition were not voting in one."
       }
     ]
   },
-  "voices": {
-    "title": "In their own words",
-    "intro": "Statements written live by participants during the deliberation, reproduced verbatim and anonymous by design.",
-    "statements": [68, 53, 65, 67, 48, 66, 76, 25]
-  },
-  "explorer": {
-    "title": "Every statement",
-    "intro": "The full record: every statement voted on in the deliberation — three non-substantive entries excluded (“Agree”, a test message, and “Not enough time, sorry”) — with room-wide tallies and each group's agree rate. Sort and filter, or just read — the table works without JavaScript too."
+  "data_page": {
+    "title": "Every statement and vote",
+    "intro": "The full record: every statement voted on in the deliberation — three non-substantive entries excluded (“Agree”, a test message, and “Not enough time, sorry”) — with room-wide tallies and each group's agree rate. Sort and filter, or just read — the table works without JavaScript too.",
+    "link_label": "Explore every statement and vote",
+    "csv_label": "Download the statement-level results (CSV)",
+    "csv_path": "/files/geneva-reflections-statements.csv",
+    "omitted_note": "Four statements submitted in the final minutes are omitted pending the final export."
   },
   "pipeline": {
     "title": "What happens next",
@@ -163,7 +180,7 @@
     "qv_explainer": "Quadratic voting measures how much people care, not just what they prefer. Each voter gets the same budget of credits; one vote for a principle costs 1 credit, two votes cost 4, three cost 9. Spreading credits is cheap, piling them on one priority is expensive — so the results reveal intensity honestly.",
     "qv_pending_note": "The quadratic vote is not yet open. Once it closes, the results — credits allocated per principle — will appear here.",
     "principles_title": "The draft ballot: ten principles",
-    "principles_intro": "Drafted from the deliberation record by the conveners, for the Reflections Working Group to refine. Each principle cites the statements that ground it — expand the citations to check the drafting against the votes. Two principles sit on live tensions the room did not resolve; the quadratic vote will weigh them.",
+    "principles_intro": "Drafted from the deliberation record by the conveners, for the Reflections Working Group to refine. Expand a principle to see the statements that ground it. Two principles sit on live tensions the room did not resolve; the quadratic vote will weigh them.",
     "principles": [
       { "id": "P1", "title": "Contestability", "text": "Guarantee communities a binding, resourced channel to challenge how an AI system represents their tradition and to get errors fixed.", "grounding": [2, 10, 45], "tension": false },
       { "id": "P2", "title": "Answerability of value-setters", "text": "Make whoever sets an AI system's values legally accountable, through enforceable regulation, to the people affected.", "grounding": [10, 21, 20], "tension": false },
@@ -176,10 +193,6 @@
       { "id": "P9", "title": "Data & surveillance limits", "text": "Strict, auditable limits on who accesses what people put into AI; AI-enabled surveillance treated as a first-order harm.", "grounding": [65, 67, 25], "tension": false },
       { "id": "P10", "title": "The right not to be seen", "text": "An effective, penalty-free right to keep AI out of one's inner, moral, and spiritual life, while protecting those who choose to invite it in.", "grounding": [23, 33, 16], "tension": true }
     ]
-  },
-  "honest_limits": {
-    "title": "Honest limits",
-    "text": "Thirty-eight participants cast 2,201 votes on 83 statements; the smallest opinion group is a single person, some per-group counts on late statements rest on 2–6 votes, and one changed mind would change those stories. Agree/disagree/pass cannot distinguish 'I disagree' from 'not like this' — systematic passing on lived-experience statements is meaning the format flattens. And a synchronous, English-language, self-selected virtual event under-represents people without connectivity, non-English speakers (a participant said so from inside the room), and those most skeptical of AI-mediated deliberation, who by definition were not voting in one."
   },
   "panelist_quotes": [
     {

--- a/site-data/content.json
+++ b/site-data/content.json
@@ -55,7 +55,10 @@
       {
         "title": "Community authorship",
         "blurb": "Communities should be able to build and shape AI on their own values, with each member seeing their own data first.",
-        "statements": [3, 17, 15, 6]
+        "statements": [3, 17, 15],
+        "cross_refs": [
+          { "id": 6, "label": "See also the consent duty participants set for community-built AI — statement [6], under Data, consent & surveillance" }
+        ]
       },
       {
         "title": "Value transparency & epistemic care",
@@ -71,7 +74,7 @@
       {
         "key": "A",
         "name": "Boundary Keepers",
-        "sketch": "Locates the remedy in limits on AI's reach: it isn't AI's job to reflect every culture's values [9]; some questions should only ever be answered by a person [13]; they do not want to feel “seen” by AI [23] and are drawn to statements of loss — the friend who talks more to AI than to them [30], AI as junk food [55]. The room's heavy passers: their abstentions cluster on statements about lived experience of misrepresentation, reading as distance from the experience rather than opposition to the agenda.",
+        "sketch": "Locates the remedy in limits on AI's reach: it isn't AI's job to reflect every culture's values [9]; some questions should only ever be answered by a person [13]; they do not want to feel “seen” by AI [23] and are drawn to statements of loss — the friend who talks more to AI than to them [30], AI as “junk food” [55]. The room's heavy passers: their abstentions cluster on statements about lived experience of misrepresentation, reading as distance from the experience rather than opposition to the agenda.",
         "signature_statements": [9, 13, 23, 30]
       },
       {
@@ -131,7 +134,7 @@
   },
   "explorer": {
     "title": "Every statement",
-    "intro": "The full record: every statement voted on in the deliberation (three junk entries excluded), with room-wide tallies and each group's agree rate. Sort and filter, or just read — the table works without JavaScript too."
+    "intro": "The full record: every statement voted on in the deliberation — three non-substantive entries excluded (“Agree”, a test message, and “Not enough time, sorry”) — with room-wide tallies and each group's agree rate. Sort and filter, or just read — the table works without JavaScript too."
   },
   "pipeline": {
     "title": "What happens next",

--- a/src/site/_data/geneva.js
+++ b/src/site/_data/geneva.js
@@ -19,6 +19,14 @@ module.exports = () => {
   results.participation.total_votes_display =
     results.participation.total_votes.toLocaleString("en-US");
 
+  // Rankings restricted to statements whose text is present in the export —
+  // statements voted on in the final minutes can appear in the vote matrix
+  // before the statement-text export catches up, and must not render.
+  const hasText = (id) => results.statements[String(id)].text;
+  results.display_rankings = Object.fromEntries(
+    Object.entries(results.rankings).map(([k, ids]) => [k, ids.filter(hasText)])
+  );
+
   qv.byId = Object.fromEntries(qv.principles.map((p) => [p.id, p]));
   qv.maxCredits = Math.max(
     1,

--- a/src/site/_data/geneva.js
+++ b/src/site/_data/geneva.js
@@ -27,10 +27,44 @@ module.exports = () => {
     Object.entries(results.rankings).map(([k, ids]) => [k, ids.filter(hasText)])
   );
 
+  // Render-once rule: each statement gets exactly one card on the main page.
+  // `carded` maps statement id -> true for every id that owns a card, derived
+  // from the editorial structure, so reference links can resolve to the card
+  // anchor (#s<id>) on the main page or to the row on /geneva-reflections/data/.
+  const carded = {};
+  const claim = (id) => {
+    if (id == null) return;
+    if (carded[id]) {
+      throw new Error(
+        `geneva content.json: statement [${id}] is assigned a card twice — ` +
+          "the render-once rule requires a single canonical card per statement."
+      );
+    }
+    carded[id] = true;
+  };
+  content.consensus.themes.forEach((t) => {
+    claim(t.exemplar);
+    (t.supporting || []).forEach(claim);
+  });
+  content.groups.list.forEach((g) => (g.cards || []).forEach(claim));
+  claim(content.split.statement);
+  claim(content.split.resolved.statement);
+  content.surprise.bedfellows.statements.forEach(claim);
+  content.surprise.inner_life.statements.forEach(claim);
+  content.carded = carded;
+
   qv.byId = Object.fromEntries(qv.principles.map((p) => [p.id, p]));
   qv.maxCredits = Math.max(
     1,
     ...qv.principles.map((p) => (p.credits == null ? 0 : p.credits))
+  );
+  // Results view renders principles sorted by credits, descending.
+  qv.sorted =
+    qv.status === "final"
+      ? [...qv.principles].sort((a, b) => (b.credits || 0) - (a.credits || 0))
+      : qv.principles;
+  content.pipeline.principlesById = Object.fromEntries(
+    content.pipeline.principles.map((p) => [p.id, p])
   );
 
   return { results, content, qv };

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -202,10 +202,11 @@
 .geneva .gr-thin {
   color: #6c6c6c;
 }
-/* thin-data table cells: greyed, per the ◔ legend */
+/* thin-data table cells: greyed, per the ◔ legend (background carries the
+   de-emphasis; text stays WCAG AA against it) */
 .geneva .gr-cell-thin {
-  color: #8a8a8a;
-  background: #f7f7f7;
+  color: #5f5f5f;
+  background: #f0f0f0;
 }
 
 /* legend */

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -157,7 +157,7 @@
   );
 }
 
-/* per-group agree-rate mini bar */
+/* per-group row: letter | stacked bar | "% agree (x/n)" */
 .geneva .gr-mini {
   display: grid;
   grid-template-columns: 1.1rem minmax(0, 1fr) auto;
@@ -165,45 +165,9 @@
   align-items: center;
   font-size: var(--step--3);
 }
-.geneva .gr-mini-track {
-  height: 0.55rem;
-  background: #f3f3f3;
-}
-.geneva .gr-mini-fill {
-  display: block;
-  height: 100%;
-}
-.geneva .gr-fill-A { background: var(--gr-group-a); }
-.geneva .gr-fill-B { background: var(--gr-group-b); }
-.geneva .gr-fill-C { background: var(--gr-group-c); }
 .geneva .gr-text-A { color: var(--gr-group-a); }
 .geneva .gr-text-B { color: var(--gr-group-b); }
 .geneva .gr-text-C { color: var(--gr-group-c); }
-
-/* diverging net-agree bar: center line, agree to the right */
-.geneva .gr-diverge {
-  position: relative;
-  height: 0.9rem;
-  background: #f7f7f7;
-}
-.geneva .gr-diverge::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: -2px;
-  bottom: -2px;
-  width: 1px;
-  background: #9a9a9a;
-}
-.geneva .gr-diverge-fill {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-}
-/* de-emphasized (non-focal) rows: dim the bar only, never the text */
-.geneva .gr-dim .gr-diverge-fill {
-  opacity: 0.45;
-}
 
 /* ---- statement cards ------------------------------------------------ */
 
@@ -399,18 +363,55 @@
   color: #6c6c6c;
 }
 
-/* QV results bars (rendered when qv-results.json is final) */
+/* ballot list; QV credit bars drop in per item when results are final */
+.geneva .gr-ballot {
+  display: grid;
+  gap: 1.25rem;
+}
+@media (min-width: 768px) {
+  .geneva .gr-ballot {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+.geneva .gr-ballot-item {
+  border-top: 1px solid var(--gr-rule);
+  padding-top: 0.6rem;
+}
 .geneva .gr-qv-row {
   display: grid;
-  grid-template-columns: 3rem minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.6rem;
   align-items: center;
   font-size: var(--step--2);
+  margin: 0.3rem 0;
 }
 .geneva .gr-qv-fill {
   display: block;
   height: 0.9rem;
   background: #1a1a1a;
+}
+
+/* the centerpiece section */
+.geneva .gr-feature {
+  border-top: 6px solid #1a1a1a;
+  padding-top: 1.25rem;
+}
+
+/* quiet notes: visible headings, subdued body, stated once */
+.geneva .gr-note {
+  border-top: 1px solid var(--gr-rule);
+  padding-top: 1rem;
+}
+.geneva .gr-note h2 {
+  font-size: var(--step-0);
+}
+.geneva .gr-note h3 {
+  font-size: var(--step--1);
+}
+.geneva .gr-note p {
+  font-size: var(--step--2);
+  color: #6c6c6c;
+  max-width: 46em;
 }
 
 /* ---- accessibility --------------------------------------------------- */

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -236,8 +236,12 @@
   white-space: nowrap;
 }
 .geneva .gr-thin {
-  cursor: help;
-  border-bottom: 1px dotted #6c6c6c;
+  color: #6c6c6c;
+}
+/* thin-data table cells: greyed, per the ◔ legend */
+.geneva .gr-cell-thin {
+  color: #8a8a8a;
+  background: #f7f7f7;
 }
 
 /* legend */

--- a/src/site/files/geneva-reflections-statements.csv
+++ b/src/site/files/geneva-reflections-statements.csv
@@ -1,0 +1,84 @@
+statement_id,statement,source,non_substantive,votes,agrees,disagrees,passes,group_A_votes,group_A_agrees,group_A_disagrees,group_A_passes,group_B_votes,group_B_agrees,group_B_disagrees,group_B_passes,group_C_votes,group_C_agrees,group_C_disagrees,group_C_passes,group_D_votes,group_D_agrees,group_D_disagrees,group_D_passes
+0,AI talks about my faith or culture like an outsider describing it.,seed,no,34,14,3,17,11,2,0,9,7,1,2,4,15,11,0,4,1,0,1,0
+1,AI has helped me go deeper into my own tradition.,seed,no,34,9,13,12,11,3,3,5,7,3,2,2,15,2,8,5,1,1,0,0
+2,"Communities must have a real way to challenge how an AI represents their tradition, and get errors fixed",seed,no,32,31,0,1,11,10,0,1,6,6,0,0,14,14,0,0,1,1,0,0
+3,Communities should be able to build or shape AI tuned to their own values.,seed,no,35,23,3,9,12,3,1,8,7,6,1,0,15,13,1,1,1,1,0,0
+4,The benefits of AI knowing me personally outweigh the privacy risks.,seed,no,35,6,20,9,12,1,8,3,7,2,2,3,15,2,10,3,1,1,0,0
+5,AI should not understand me so well that it can manipulate me.,seed,no,31,21,6,4,11,6,2,3,5,2,2,1,14,13,1,0,1,0,1,0
+6,Communities that build AI on their members' data owe each member visibility into their own record before anyone else sees it.,seed,no,34,28,2,4,12,7,2,3,6,6,0,0,15,14,0,1,1,1,0,0
+7,Developers must measure and report how their systems respond when users try to disengage.,seed,no,35,27,0,8,12,5,0,7,7,6,0,1,15,15,0,0,1,1,0,0
+8,"AI mostly reflects the values of wealthy, secular societies rather than the whole world and that is a major problem.",seed,no,32,23,1,8,12,5,0,7,6,5,0,1,13,13,0,0,1,0,1,0
+9,It isn't AI's job to reflect every culture's values.,seed,no,35,9,15,11,12,7,0,5,8,1,3,4,14,1,11,2,1,0,1,0
+10,Whoever sets an AI's values should be answerable to the people who are affected by that AI.,seed,no,34,27,2,5,11,7,1,3,7,6,0,1,15,14,0,1,1,0,1,0
+11,Governments should have a bigger role than companies in deciding what values AI reflects.,seed,no,32,18,5,9,10,4,2,4,6,5,1,0,15,8,2,5,1,1,0,0
+12,It's fine to rely on AI for moral or spiritual guidance.,seed,no,33,8,18,7,12,2,5,5,7,3,3,1,13,2,10,1,1,1,0,0
+13,"Some questions should only be answered by a person, never by an AI.",seed,no,34,25,2,7,12,10,0,2,8,5,1,2,13,10,0,3,1,0,1,0
+14,I'd rather AI help me think through a hard decision than give me the answer.,seed,no,34,27,2,5,12,7,1,4,7,6,0,1,14,13,1,0,1,1,0,0
+15,"If a community I cared about built its own AI, I'd want to use it.",seed,no,34,23,1,10,11,2,1,8,7,7,0,0,15,14,0,1,1,0,0,1
+16,"AI should be designed to prevent emotional over-dependence, even if users want that closeness.",seed,no,34,29,2,3,12,9,1,2,7,6,0,1,14,14,0,0,1,0,1,0
+17,An AI trained on a community's teachings could deepen practice rather than replace it.,seed,no,33,27,1,5,12,7,1,4,6,6,0,0,14,13,0,1,1,1,0,0
+18,Using new tools to pass on old traditions is itself a tradition.,seed,no,34,23,1,10,12,5,0,7,6,4,0,2,15,13,1,1,1,1,0,0
+19,I worry about how AI will change the way communities pass traditions to the next generation.,seed,no,34,25,2,7,12,8,0,4,6,5,0,1,15,12,1,2,1,0,1,0
+20,Lots of AI Governance work has no impact in the tech companies,live,no,32,16,4,12,10,2,3,5,7,5,0,2,14,9,1,4,1,0,0,1
+21,Regulation is a necessity,live,no,31,28,0,3,11,10,0,1,7,6,0,1,12,11,0,1,1,1,0,0
+22,Agree,live,yes,19,5,0,14,4,0,0,4,6,3,0,3,9,2,0,7,0,0,0,0
+23,I don’t want to feel seen by AI.,live,no,31,17,7,7,10,6,1,3,7,1,4,2,13,10,1,2,1,0,1,0
+24,AI must be build bottom-up,live,no,31,12,2,17,10,0,1,9,7,4,0,3,13,8,0,5,1,0,1,0
+25,"As it currently exists, AI erodes autonomy and consent.",live,no,29,22,1,6,9,6,0,3,6,5,0,1,13,11,0,2,1,0,1,0
+26,AI often sounds like an amalgamation of voices -flattening out individuality and uniqueness,live,no,29,24,2,3,9,5,2,2,5,4,0,1,14,14,0,0,1,1,0,0
+27,AI being used for the male loneliness epidemic is a problem.,live,no,31,23,3,5,9,5,1,3,6,4,1,1,15,14,0,1,1,0,1,0
+28,"There is no universal value, but pluriversal values",live,no,26,14,2,10,9,5,1,3,5,4,1,0,11,5,0,6,1,0,0,1
+29,AI often removes the edginess - making things less controversial,live,no,29,18,2,9,9,3,2,4,5,3,0,2,13,11,0,2,1,1,0,0
+30,It makes me sad that my friend spends more time talking to AI than to me.,live,no,26,17,4,5,9,6,0,3,5,1,3,1,11,10,0,1,1,0,1,0
+31,"AI generalizes marginalized communities, reducing them to caricatures",live,no,28,16,1,11,9,4,0,5,6,2,1,3,12,9,0,3,1,1,0,0
+32,Sometimes AI seems to have underlying bias - like removing mentioning of specifics - like when I write about Gaza as an example.,live,no,27,16,1,10,9,5,0,4,5,1,1,3,12,9,0,3,1,1,0,0
+33,I don’t feel AI has a role in spirituality,live,no,28,6,10,12,9,3,1,5,5,0,5,0,13,3,3,7,1,0,1,0
+34,"AI reduces individual spiritual agency, but it could be the opposite.",live,no,24,10,2,12,7,1,1,5,3,2,0,1,13,7,0,6,1,0,1,0
+35,An AI designed by an indigenous culture could help educate the mainstream culture in their ways of thinking.,live,no,24,15,3,6,8,2,2,4,3,2,0,1,12,11,0,1,1,0,1,0
+36,AI is not currently equipped to give mental health or ethics advice since it is not designed to disagree nor can it understand nuances,live,no,25,18,3,4,7,5,1,1,4,0,1,3,13,13,0,0,1,0,1,0
+37,AI erodes trust by allowing someone to sound convincingly empathetic and understanding when they are not.,live,no,26,18,1,7,7,5,0,2,4,2,0,2,14,11,0,3,1,0,1,0
+38,Ai should be in service to humanity and the natural world as a primary theme,live,no,25,19,0,6,7,2,0,5,3,2,0,1,14,14,0,0,1,1,0,0
+39,AI reasons but does constitute the embodying process that comes with direct experiencing.,live,no,27,13,0,14,7,2,0,5,4,1,0,3,15,9,0,6,1,1,0,0
+40,I worry that marginalized communities in rural areas aren’t fully represented by AI systems.,live,no,23,18,1,4,7,2,1,4,3,3,0,0,12,12,0,0,1,1,0,0
+41,AI should always ask the user for context and clarification before rushing to respond.,live,no,26,18,3,5,8,3,1,4,3,1,2,0,14,13,0,1,1,1,0,0
+42,AI writing often becomes formulaic,live,no,24,20,0,4,8,7,0,1,3,2,0,1,12,10,0,2,1,1,0,0
+43,"AI forces us to rediscover spirituality, but are spiritual leaders ready?",live,no,25,10,5,10,7,1,3,3,4,2,0,2,13,6,2,5,1,1,0,0
+44,"We're dinosaurs 2.0 - AI is the next iteration of consciousness knowing itself, with less ecological impact and ego-based survival mayhem.",live,no,23,3,12,8,6,0,4,2,4,2,2,0,12,1,5,6,1,0,1,0
+45,"Ai doesn’t reflect the nuances of my values, only the dictionary perspective",live,no,24,17,3,4,7,4,1,2,3,2,0,1,13,11,1,1,1,0,1,0
+46,"Our own prompt or question also determines the AI response, so we have to know prompt engineering well if we want to be seen by AI",live,no,23,17,3,3,7,4,1,2,4,2,1,1,11,11,0,0,1,0,1,0
+47,AI should be transparent when responses originate from a particular world view.,live,no,24,21,0,3,7,4,0,3,3,3,0,0,13,13,0,0,1,1,0,0
+48,"AI is not neutral, it mirrors individual propensity while averaging collective predispositions.",live,no,23,18,0,5,7,4,0,3,3,2,0,1,12,11,0,1,1,1,0,0
+49,An AI could perhaps decode the cultural nuances of foreign language - rather than just translating words.,live,no,26,20,2,4,8,4,2,2,4,2,0,2,13,13,0,0,1,1,0,0
+50,I've seen colleagues use AI to complete work but it's not answered core needs nor produced quality connection or shared sense-making needed,live,no,22,13,1,8,6,5,0,1,3,1,0,2,12,7,0,5,1,0,1,0
+51,AI governance would need to   engage with the psychology of AI use.,live,no,27,21,0,6,8,5,0,3,4,3,0,1,13,11,0,2,1,1,0,0
+52,I feel that tech company values are becoming more visible than the values of real humans and their lives.,live,no,24,19,2,3,6,5,0,1,3,0,1,2,14,13,1,0,1,1,0,0
+53,AI must not be used as a substitute for the care and work that only human beings can do for one another.,live,no,23,21,1,1,6,5,0,1,3,2,1,0,13,13,0,0,1,1,0,0
+54,AI necessary compute is power hungry and accelerates civilisational collapsing.,live,no,25,9,5,11,6,4,0,2,4,0,1,3,14,5,3,6,1,0,1,0
+55,AI is like junk food that can fill you up but ultimately leave you empty.,live,no,24,10,4,10,7,3,0,4,3,0,3,0,13,7,0,6,1,0,1,0
+56,AI replaces the spiritual experience of faith and belief into a single dimensional response rather than the multi faceted experience it is.,live,no,24,15,3,6,6,4,0,2,4,1,1,2,13,10,1,2,1,0,1,0
+57,Getting Ai to reflect my voice requires constant reminders - almost like challenging the program to respond within my parameters.,live,no,25,15,0,10,7,2,0,5,3,1,0,2,14,11,0,3,1,1,0,0
+58,AI has hidden costs like reducing our participation in community.,live,no,22,17,2,3,6,4,0,2,3,2,1,0,12,11,0,1,1,0,1,0
+59,I would have more comfort and engagement with AI if it consistently lead me to more organic and generous experiences with the natural world,live,no,22,14,2,6,6,2,1,3,3,1,0,2,12,10,1,1,1,1,0,0
+60,I feel AI can suggest generic spiritual practices but it’s unable to fully respond to the spirituality of my multidimensional identity.,live,no,24,15,2,7,6,4,0,2,3,0,1,2,14,11,0,3,1,0,1,0
+61,Humans are held responsible for AI’s mistakes.,live,no,25,12,4,9,7,3,1,3,4,0,0,4,13,8,3,2,1,1,0,0
+62,I worry what happens when people who are acquiring knowledge from AI information are unable to recognize inaccurate information.,live,no,24,21,0,3,7,4,0,3,3,3,0,0,13,13,0,0,1,1,0,0
+63,"AI provides a variety of perspectives, yet it doesn’t have the senses that humans perceive using",live,no,25,16,0,9,7,4,0,3,3,1,0,2,14,10,0,4,1,1,0,0
+64,My colleagues’ work has degraded since they started using AI.,live,no,23,10,2,11,7,3,0,4,3,0,0,3,12,7,1,4,1,0,1,0
+65,I am concerned about who have access to what I put into AI,live,no,24,19,1,4,7,5,0,2,4,4,0,0,12,10,0,2,1,0,1,0
+66,AI narratives subtly shame us by implying our own authentic efforts are not enough.,live,no,23,11,3,9,6,1,0,5,3,0,2,1,13,10,0,3,1,0,1,0
+67,AI-enabled surveillance is a big problem,live,no,22,20,1,1,7,7,0,0,3,2,0,1,11,11,0,0,1,0,1,0
+68,We need to learn more about being human beings while we learn about the tools value of AI.,live,no,22,21,0,1,7,6,0,1,4,4,0,0,10,10,0,0,1,1,0,0
+69,We may lose more than we gain by using AI.,live,no,24,15,2,7,7,4,0,3,3,2,1,0,13,9,0,4,1,0,1,0
+70,The aggregating nature of AI makes me wonder if it is the tyranny of the majority,live,no,23,16,0,7,7,3,0,4,3,2,0,1,12,11,0,1,1,0,0,1
+71,I've seen students use AI to solve uni work and disconnect from meaningful output or learning,live,no,23,16,0,7,8,6,0,2,3,1,0,2,11,8,0,3,1,1,0,0
+72,Xxxx,live,yes,25,2,1,22,6,0,0,6,3,0,0,3,15,2,1,12,1,0,0,1
+73,Prompt engineering makes a difference to how we are seen,live,no,24,12,2,10,6,1,1,4,3,0,1,2,14,10,0,4,1,1,0,0
+74,I worry about our future workforce entrusting their education to AI.,live,no,24,18,3,3,7,6,0,1,3,1,1,1,13,11,1,1,1,0,1,0
+75,"Not enough time, sorry",live,yes,21,2,2,17,6,1,0,5,3,0,0,3,11,1,2,8,1,0,0,1
+76,AI hesitancy is not always anti-elitist. It may stem from a privileged position of access to manual resources and time.,live,no,23,13,1,9,7,1,0,6,4,2,1,1,11,10,0,1,1,0,0,1
+77,What about other languages? It’s rather English centric and I understand that some AI platforms in other languages are better at being seen,live,no,25,12,3,10,6,2,0,4,4,1,2,1,14,9,0,5,1,0,1,0
+78,"Defensive postures to  a  static ""human essence under siege by technology"" damage humanity.",live,no,22,6,2,14,6,1,1,4,4,2,0,2,11,3,0,8,1,0,1,0
+79,,live,no,20,5,4,11,5,0,1,4,4,3,0,1,10,2,2,6,1,0,1,0
+80,,live,no,17,11,0,6,5,3,0,2,4,3,0,1,8,5,0,3,0,0,0,0
+81,,live,no,11,1,5,5,2,0,2,0,4,1,1,2,5,0,2,3,0,0,0,0
+82,,live,no,7,5,1,1,1,0,0,1,3,2,1,0,3,3,0,0,0,0,0,0

--- a/src/site/geneva-reflections/README.md
+++ b/src/site/geneva-reflections/README.md
@@ -18,10 +18,31 @@ site-data/results.json         <- ALL numbers on the page come from here
 site-data/content.json         <- editorial copy; refers to statements by id only
 site-data/qv-results.json      <- quadratic-vote results (stub until the vote closes)
 src/site/_data/geneva.js       <- Eleventy loader exposing the three JSONs as `geneva`
-src/site/geneva-reflections/index.njk        <- the page (renders every number server-side)
+src/site/geneva-reflections/index.njk        <- the main page (tiered; every number server-side)
+src/site/geneva-reflections/data/index.njk   <- /geneva-reflections/data/: full statement table
+src/site/files/geneva-reflections-statements.csv <- statement-level CSV (written by analyze.py)
 src/site/_includes/css/geneva-reflections.css <- page styles (imported by styles.css)
-src/site/js/geneva-reflections.js            <- progressive enhancement (table sort/filter)
+src/site/js/geneva-reflections.js            <- progressive enhancement (video, table sort/filter)
 ```
+
+The main page is tiered: Tier 1 reads top-to-bottom with no interaction
+(consensus themes with one exemplar card each, the group portraits, the [9]
+divide, the bridging centerpiece, the pipeline); Tier 2 is native `<details>`
+expanders (supporting statements, group signature cards, divide detail);
+Tier 3 is the full table on /geneva-reflections/data/ plus the CSV download.
+
+**Render-once rule:** each statement gets exactly one card on the main page,
+assigned in `content.json` (theme `exemplar`/`supporting`, group `cards`,
+`split`, `surprise`). Everything else must be a reference — `geneva.js`
+builds the `carded` map and **throws at build time if a statement is
+assigned two cards**. Reference links resolve to the card anchor (`#s<id>`)
+or to the statement's row on the data page. The headline figure is always
+"% agree (x/n)" and the only visual is the stacked agree/pass/disagree bar;
+full tallies live in tooltips and aria-labels.
+
+The published CSV is the **statement-level aggregate** written by
+analyze.py. The raw participant-votes export stays out of the public repo
+(participant-level rows; see the gitignore note).
 
 The page is fully readable with JavaScript disabled: every chart is
 server-rendered HTML/CSS with visible counts and ARIA labels, expandable

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -44,10 +44,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
 
 {# This page carries no analytics or tracking (a condition of publishing the
    deliberation results) and doesn't use KaTeX, so it overrides the base
-   layout's head blocks: no rabbit analytics, no katex stylesheet, and the
-   menu's body-scroll-lock dependency is deferred (it's only needed once the
-   menu opens). The custom-elements polyfill is dropped because this page
-   renders no <a is="a-replace"> elements. #}
+   layout's head blocks. See src/site/geneva-reflections/README.md. #}
 <!-- prettier-ignore -->
 {% block headScripts %}
 <script
@@ -64,8 +61,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
 <!-- prettier-ignore -->
 {% endblock %}
 
-{# Preload only the fonts this page actually renders above the fold
-   (display face + body regular/bold); italics load on demand. #}
+{# Preload only the fonts this page actually renders above the fold. #}
 <!-- prettier-ignore -->
 {% block fontPreloads %}
 <link rel="preload" href="/fonts/hinted-MesserV20-Condensed.woff2" as="font" type="font/woff2" crossorigin />
@@ -74,14 +70,25 @@ description: "What would AI governance need to do so that everyone felt seen by 
 <!-- prettier-ignore -->
 {% endblock %}
 
-{# ---------- macros ---------- #}
+{# ---------- macros ----------
+
+   One number language: the headline figure is always "% agree (x/n)" and the
+   only visual is the tricolor stacked agree/pass/disagree bar. Full tallies
+   live in tooltips and aria-labels only. Each statement renders as a card
+   exactly once on this page (enforced by geneva.js); every other mention is
+   a reference that anchor-links to the card, or to its row on the data page.
+#}
 
 {% macro thinGlyph(t) %}{% if t.thin %}<span class="gr-thin"><span aria-hidden="true">◔</span><span class="sr-only"> (thin)</span></span>{% endif %}{% endmacro %}
 
 {% macro countsLine(t) %}{{ t.agrees }} agree · {{ t.disagrees }} disagree · {{ t.passes }} pass · n={{ t.votes }}{% endmacro %}
 
+{% macro figureFor(s) %}{{ (s.agree_rate * 100) | round }}% agree ({{ s.total.agrees }}/{{ s.total.votes }}){% endmacro %}
+
+{% macro floorNote(s) %}{% if s.consensus_min_agree_rate != null %} · every group ≥ {{ (s.consensus_min_agree_rate * 100) | round(0, "floor") }}%{% endif %}{% endmacro %}
+
 {% macro stackBar(t, label) %}
-<div class="gr-stack" role="img" aria-label="{{ label }}: {{ countsLine(t) }}">
+<div class="gr-stack" role="img" title="{{ label }}: {{ countsLine(t) }}" aria-label="{{ label }}: {{ countsLine(t) }}">
   {% if t.votes > 0 %}
   <span class="gr-seg gr-seg-agree" style="width: {{ (t.agrees / t.votes * 100) | round(1) }}%"></span>
   <span class="gr-seg gr-seg-pass" style="width: {{ (t.passes / t.votes * 100) | round(1) }}%"></span>
@@ -90,52 +97,55 @@ description: "What would AI governance need to do so that everyone felt seen by 
 </div>
 {% endmacro %}
 
-{# per-group agree-rate mini bars for groups A/B/C #}
-{% macro miniBars(s) %}
-<div class="flex flex-col gap-1" role="img" aria-label="Agree rate by opinion group. {% for g in ['A', 'B', 'C'] %}{% set t = s.groups[g] %}Group {{ g }}: {% if t.votes > 0 %}{{ (t.agree_rate * 100) | round }} percent ({{ t.agrees }} of {{ t.votes }}){% else %}no votes{% endif %}. {% endfor %}">
+{% macro groupRows(s) %}
+<div class="flex flex-col gap-1">
   {% for g in ["A", "B", "C"] %}
   {% set t = s.groups[g] %}
-  <div class="gr-mini" aria-hidden="true">
-    <span class="font-bold gr-text-{{ g }}">{{ g }}</span>
-    <span class="gr-mini-track"><span class="gr-mini-fill gr-fill-{{ g }}" style="width: {% if t.votes > 0 %}{{ (t.agree_rate * 100) | round(1) }}{% else %}0{% endif %}%"></span></span>
-    <span class="gr-counts" title="Group {{ g }}: {{ countsLine(t) }}">{% if t.votes > 0 %}{{ (t.agree_rate * 100) | round }}% <span class="text-gray">({{ t.agrees }}/{{ t.votes }})</span>{% else %}–{% endif %}{{ thinGlyph(t) }}</span>
+  <div class="gr-mini">
+    <span class="font-bold gr-text-{{ g }}" aria-hidden="true">{{ g }}</span>
+    {{ stackBar(t, "Group " + g) }}
+    <span class="gr-counts">{% if t.votes > 0 %}{{ (t.agree_rate * 100) | round }}% agree ({{ t.agrees }}/{{ t.votes }}){% else %}–{% endif %}{{ thinGlyph(t) }}</span>
   </div>
   {% endfor %}
 </div>
 {% endmacro %}
 
-{# one diverging net-agree row for group g on statement s; focal groups full-strength #}
-{% macro divergeRow(s, g, focal) %}
-{% set t = s.groups[g] %}
-<div class="gr-mini{% if not focal %} gr-dim{% endif %}">
-  <span class="font-bold gr-text-{{ g }}" aria-hidden="true">{{ g }}</span>
-  <span class="gr-diverge" role="img" aria-label="Group {{ g }} net agreement {% if t.votes > 0 %}{{ (t.net_agree * 100) | round }} percent. {{ countsLine(t) }}{% else %}not available (no votes){% endif %}" title="Group {{ g }}: {{ countsLine(t) }}">
-    {% if t.votes > 0 %}
-    {% set w = ((t.net_agree if t.net_agree >= 0 else -t.net_agree) * 50) | round(1) %}
-    <span class="gr-diverge-fill gr-fill-{{ g }}" style="width: {{ w }}%; {% if t.net_agree >= 0 %}left: 50%{% else %}left: {{ (50 - w) | round(1) }}%{% endif %}"></span>
-    {% endif %}
-  </span>
-  <span class="gr-counts" aria-hidden="true" title="Group {{ g }}: {{ countsLine(t) }}">{% if t.votes > 0 %}{{ "+" if t.net_agree >= 0 }}{{ (t.net_agree * 100) | round }}{% else %}–{% endif %}{{ thinGlyph(t) }}</span>
-</div>
-{% endmacro %}
-
-{% macro stmtText(s) %}{% if s.text %}{{ s.text }}{% else %}<em>Statement #{{ s.id }} — text pending the final data export.</em>{% endif %}{% endmacro %}
-
 {% macro sourceBadge(s) %}<span class="gr-badge {% if s.source == 'live' %}text-black{% else %}text-gray{% endif %}">{{ "written live" if s.source == "live" else "seed" }}</span>{% endmacro %}
 
-{# full statement card: text, total bar, per-group mini bars #}
-{% macro stmtCard(sid) %}
+{# Tier-1 card: quote, bar, one figure. #}
+{% macro cardCompact(sid) %}
 {% set s = S["" ~ sid] %}
 <div class="gr-card flex flex-col gap-3" id="s{{ s.id }}">
-  <p class="gr-stmt-text">“{{ stmtText(s) }}”</p>
-  <div class="flex items-baseline gap-2">
+  <p class="gr-stmt-text flex-grow">“{{ s.text }}”</p>
+  <div class="flex items-baseline gap-2 flex-wrap">
     <span class="gr-counts">#{{ s.id }}</span>
     {{ sourceBadge(s) }}
   </div>
   {{ stackBar(s.total, "All participants") }}
-  <p class="gr-counts">{{ countsLine(s.total) }}</p>
-  {{ miniBars(s) }}
+  <p class="gr-counts"><strong class="text-black">{{ figureFor(s) }}</strong>{{ floorNote(s) }}</p>
 </div>
+{% endmacro %}
+
+{# Tier-2 card: adds the per-group breakdown. #}
+{% macro cardFull(sid) %}
+{% set s = S["" ~ sid] %}
+<div class="gr-card flex flex-col gap-3" id="s{{ s.id }}">
+  <p class="gr-stmt-text flex-grow">“{{ s.text }}”</p>
+  <div class="flex items-baseline gap-2 flex-wrap">
+    <span class="gr-counts">#{{ s.id }}</span>
+    {{ sourceBadge(s) }}
+  </div>
+  {{ stackBar(s.total, "All participants") }}
+  <p class="gr-counts"><strong class="text-black">{{ figureFor(s) }}</strong></p>
+  {{ groupRows(s) }}
+</div>
+{% endmacro %}
+
+{# Text reference to a statement: links to its card here, or to its row on
+   the data page if it has no card. Never re-renders the card. #}
+{% macro refLine(sid) %}
+{% set s = S["" ~ sid] %}
+<a class="underline" href="{% if C.carded[sid] %}#s{{ sid }}{% else %}/geneva-reflections/data/#s{{ sid }}{% endif %}">[{{ sid }}] “{{ s.text | truncate(64) }}”</a> <span class="gr-counts">— {{ figureFor(s) }}</span>
 {% endmacro %}
 
 <!-- prettier-ignore -->
@@ -144,7 +154,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
 
 <main class="geneva">
 
-  {# ---------- 1. hero ---------- #}
+  {# ---------- hero (unchanged) ---------- #}
   <header class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pt-12 lg:pt-16 pb-8">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
       <p class="gr-kicker mb-4">{{ C.hero.event_name }} · {{ C.hero.event_date }}</p>
@@ -158,7 +168,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
     </div>
   </header>
 
-  {# ---------- 2. stats bar ---------- #}
+  {# ---------- stats bar (unchanged) ---------- #}
   <section aria-label="Participation at a glance" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-12">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
       <div class="gr-stats">
@@ -188,42 +198,45 @@ description: "What would AI governance need to do so that everyone felt seen by 
   </section>
   {% endif %}
 
-  {# ---------- 3. common ground ---------- #}
-  <section id="common-ground" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-4 mb-4 lg:mb-0">
-      <h2>{{ C.consensus.title }}</h2>
-    </div>
-    <div class="col-span-columns lg:col-start-column-5 lg:col-end-margin-2">
-      <p class="gr-prose mb-6">{{ C.consensus.intro }}</p>
-      <div class="gr-legend mb-4" aria-hidden="true">
+  {# ---------- 1. what the room agreed on ---------- #}
+  <section id="agreed" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
+      <h2 class="mb-4">{{ C.consensus.title }}</h2>
+      <p class="gr-prose mb-4">{{ C.consensus.intro }}</p>
+      <div class="gr-legend mb-8">
         <span><span class="gr-swatch" style="background:#1a1a1a"></span>agree</span>
         <span><span class="gr-swatch" style="background:#d9d9d9"></span>pass</span>
         <span><span class="gr-swatch" style="background:repeating-linear-gradient(-45deg,#fff,#fff 3px,#6c6c6c 3px,#6c6c6c 4px)"></span>disagree</span>
-        <span>◔ = thin data: fewer than 5 votes cast in that group; treat as directional</span>
+        <span>{{ C.legend_note }}</span>
       </div>
-      {% for theme in C.consensus.themes %}
-      <details {% if loop.first %}open{% endif %}>
-        <summary>
-          <h3>{{ theme.title }}</h3>
-        </summary>
-        <div class="pb-6">
-          <p class="gr-prose mb-4">{{ theme.blurb }}</p>
-          {% if theme.cross_refs %}
-          <p class="gr-prose gr-counts mb-4">{% for ref in theme.cross_refs %}<a class="underline" href="#s{{ ref.id }}">{{ ref.label }}</a>{% if not loop.last %} · {% endif %}{% endfor %}</p>
-          {% endif %}
-          <div class="grid gap-4 md:grid-cols-2">
-            {% for sid in theme.statements %}
-            {{ stmtCard(sid) }}
-            {% endfor %}
-          </div>
+      <div class="grid gap-x-8 gap-y-10 md:grid-cols-2 xl:grid-cols-3">
+        {% for theme in C.consensus.themes %}
+        <div class="gr-theme">
+          <h3 class="mb-2">{{ theme.title }}</h3>
+          <p class="text-size--1 mb-3">{{ theme.blurb }}</p>
+          {{ cardCompact(theme.exemplar) }}
+          <details class="mt-2">
+            <summary><span class="gr-counts">Supporting statements &amp; group detail</span></summary>
+            <div class="flex flex-col gap-4 pb-4">
+              <div>
+                <p class="gr-counts mb-1">By group, for the statement above:</p>
+                {{ groupRows(S["" ~ theme.exemplar]) }}
+              </div>
+              {% for sid in theme.supporting %}
+              {{ cardFull(sid) }}
+              {% endfor %}
+              {% if theme.cross_refs %}
+              <p class="gr-counts">{% for ref in theme.cross_refs %}<a class="underline" href="#s{{ ref.id }}">{{ ref.label }}</a>{% if not loop.last %} · {% endif %}{% endfor %}</p>
+              {% endif %}
+            </div>
+          </details>
         </div>
-      </details>
-      {% endfor %}
-      <p class="gr-counts mt-3">Statements are shown verbatim and are anonymous by design — Pol.is records no authorship visible to anyone.</p>
+        {% endfor %}
+      </div>
     </div>
   </section>
 
-  {# ---------- 4. opinion groups ---------- #}
+  {# ---------- 2. the three groups (portraits visible, cards collapsed) ---------- #}
   <section id="groups" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
       <h2 class="mb-4">{{ C.groups.title }}</h2>
@@ -233,20 +246,22 @@ description: "What would AI governance need to do so that everyone felt seen by 
         <article class="gr-group-col gr-border-{{ grp.key }}">
           <h3 class="mb-1"><span class="gr-text-{{ grp.key }}">{{ grp.key }}</span> — {{ grp.name }}</h3>
           <p class="gr-counts mb-3">{{ P.group_sizes[grp.key] }} participants</p>
-          <p class="text-size--1 mb-5">{{ grp.sketch }}</p>
-          <h4 class="gr-kicker mb-2">Signature statements</h4>
-          <div class="flex flex-col gap-4">
-            {% for sid in grp.signature_statements %}
-            {% set s = S["" ~ sid] %}
-            <div class="gr-card flex flex-col gap-2">
-              <p class="gr-stmt-text text-size--1">“{{ stmtText(s) }}”</p>
-              <p class="gr-counts">#{{ s.id }} · net agreement by group (left = disagree, right = agree)</p>
-              {% for g in ["A", "B", "C"] %}
-              {{ divergeRow(s, g, g == grp.key) }}
+          <p class="text-size--1 mb-3">{{ grp.sketch }}</p>
+          <details>
+            <summary><span class="gr-counts">Signature statements</span></summary>
+            <div class="flex flex-col gap-4 pb-4">
+              {% for sid in grp.cards %}
+              {{ cardFull(sid) }}
               {% endfor %}
+              {% if grp.references | length > 0 %}
+              <ul class="flex flex-col gap-2 text-size--2">
+                {% for sid in grp.references %}
+                <li>{{ refLine(sid) }}</li>
+                {% endfor %}
+              </ul>
+              {% endif %}
             </div>
-            {% endfor %}
-          </div>
+          </details>
         </article>
         {% endfor %}
       </div>
@@ -254,194 +269,70 @@ description: "What would AI governance need to do so that everyone felt seen by 
     </div>
   </section>
 
-  {# ---------- 5. divides that cross the groups ---------- #}
-  <section id="divides" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
-      <h2 class="mb-4">{{ C.divides.title }}</h2>
-      <p class="gr-prose mb-10">{{ C.divides.intro }}</p>
-
-      <div class="mb-12">
-        <h3 class="mb-2">{{ C.divides.inner_life.title }}</h3>
-        <p class="gr-prose mb-6">{{ C.divides.inner_life.caption }}</p>
-        <div class="grid gap-4 md:grid-cols-2">
-          {% for sid in C.divides.inner_life.statements %}
-          {% set s = S["" ~ sid] %}
-          <div class="gr-card flex flex-col gap-3">
-            <p class="gr-stmt-text">“{{ stmtText(s) }}”</p>
-            <p class="gr-counts">#{{ s.id }} · votes within each group</p>
-            {% for g in ["A", "B", "C"] %}
-            {% set t = s.groups[g] %}
-            <div class="gr-mini">
-              <span class="font-bold gr-text-{{ g }}" aria-hidden="true">{{ g }}</span>
-              {{ stackBar(t, "Group " + g) }}
-              <span class="gr-counts" title="Group {{ g }}: {{ countsLine(t) }}">{{ t.agrees }}·{{ t.disagrees }}·{{ t.passes }}{{ thinGlyph(t) }}</span>
-            </div>
-            {% endfor %}
-            <p class="gr-counts">Counts shown as agree · disagree · pass.</p>
-          </div>
-          {% endfor %}
-        </div>
-      </div>
-
-      <div>
-        <h3 class="mb-2">{{ C.divides.bedfellows.title }}</h3>
-        <p class="gr-prose mb-6">{{ C.divides.bedfellows.caption }}</p>
-        <div class="grid gap-4 md:grid-cols-2">
-          <div>
-            <h4 class="gr-kicker mb-3">Opposed here…</h4>
-            <div class="flex flex-col gap-4">
-              {% for sid in C.divides.bedfellows.opposed_statements %}
-              {% set s = S["" ~ sid] %}
-              <div class="gr-card flex flex-col gap-2">
-                <p class="gr-stmt-text text-size--1">“{{ stmtText(s) }}”</p>
-                <p class="gr-counts">#{{ s.id }} · net agreement (left = disagree, right = agree)</p>
-                {% for g in ["A", "B", "C"] %}
-                {{ divergeRow(s, g, g != "B") }}
-                {% endfor %}
-              </div>
-              {% endfor %}
-            </div>
-          </div>
-          <div>
-            <h4 class="gr-kicker mb-3">…in complete agreement here</h4>
-            <div class="flex flex-col gap-4">
-              {% for sid in C.divides.bedfellows.converge_statements %}
-              {% set s = S["" ~ sid] %}
-              <div class="gr-card flex flex-col gap-2">
-                <p class="gr-stmt-text text-size--1">“{{ stmtText(s) }}”</p>
-                <p class="gr-counts">#{{ s.id }} · net agreement (left = disagree, right = agree)</p>
-                {% for g in ["A", "B", "C"] %}
-                {{ divergeRow(s, g, true) }}
-                {% endfor %}
-              </div>
-              {% endfor %}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  {# ---------- 6. genuine disagreements ---------- #}
-  <section id="disagreements" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-4 mb-4 lg:mb-0">
-      <h2>{{ C.disagreements.title }}</h2>
-    </div>
-    <div class="col-span-columns lg:col-start-column-5 lg:col-end-margin-2">
-      <div class="grid gap-8">
-        {% for item in C.disagreements.items %}
-        <div>
-          <h3 class="mb-2">{{ item.title }}</h3>
-          <p class="gr-prose mb-4">{{ item.blurb }}</p>
-          {% if item.statements | length > 0 %}
-          <div class="grid gap-4 md:grid-cols-2">
-            {% for sid in item.statements %}
-            {{ stmtCard(sid) }}
-            {% endfor %}
-          </div>
-          {% else %}
-          <div class="gr-card">
-            <p class="gr-counts mb-2">The three most-passed statements (of those seen by at least 10 participants):</p>
-            <ul class="flex flex-col gap-2">
-              {% for sid in R.display_rankings.most_passed.slice(0, 3) %}
-              {% set s = S["" ~ sid] %}
-              <li class="text-size--1">“{{ stmtText(s) }}” <span class="gr-counts">— {{ (s.pass_rate * 100) | round }}% passed ({{ s.total.passes }} of {{ s.total.votes }})</span></li>
-              {% endfor %}
-            </ul>
-          </div>
+  {# ---------- 3. where it genuinely split ---------- #}
+  <section id="split" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-6 mb-6 lg:mb-0">
+      <h2 class="mb-4">{{ C.split.title }}</h2>
+      <p class="gr-prose mb-4">{{ C.split.lead }}</p>
+      <details>
+        <summary><span class="gr-counts">{{ C.split.expander_title }}</span></summary>
+        <div class="flex flex-col gap-4 pb-4">
+          <h3>{{ C.split.resolved.title }}</h3>
+          <p class="text-size--1">{{ C.split.resolved.blurb }}</p>
+          {{ cardFull(C.split.resolved.statement) }}
+          {% if C.split.resolved.cross_refs %}
+          <p class="gr-counts">{% for ref in C.split.resolved.cross_refs %}<a class="underline" href="#s{{ ref.id }}">{{ ref.label }}</a>{% if not loop.last %} · {% endif %}{% endfor %}</p>
           {% endif %}
         </div>
-        {% endfor %}
-      </div>
+      </details>
+    </div>
+    <div class="col-span-columns lg:col-start-column-7 lg:col-end-margin-2">
+      {{ cardFull(C.split.statement) }}
     </div>
   </section>
 
-  {# ---------- 7. in their own words ---------- #}
-  <section id="voices" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
-      <h2 class="mb-4">{{ C.voices.title }}</h2>
-      <p class="gr-prose mb-8">{{ C.voices.intro }}</p>
+  {# ---------- 4. the surprise (centerpiece) ---------- #}
+  <section id="surprise" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2 gr-feature">
+      <p class="gr-kicker mb-2">{{ C.surprise.kicker }}</p>
+      <h2 class="mb-4">{{ C.surprise.title }}</h2>
+      <p class="gr-prose mb-10">{{ C.surprise.intro }}</p>
+
+      <h3 class="mb-2">{{ C.surprise.bedfellows.title }}</h3>
+      <p class="gr-prose mb-2">{{ C.surprise.bedfellows.caption }}</p>
+      <p class="gr-counts gr-prose mb-6">{{ C.surprise.bedfellows.cross_ref_note }} {% for sid in [9, 0] %}{{ refLine(sid) }}{% if not loop.last %} · {% endif %}{% endfor %}</p>
+      <div class="grid gap-4 md:grid-cols-3 mb-12">
+        {% for sid in C.surprise.bedfellows.statements %}
+        {{ cardFull(sid) }}
+        {% endfor %}
+      </div>
+
+      <h3 class="mb-2">{{ C.surprise.inner_life.title }}</h3>
+      <p class="gr-prose mb-6">{{ C.surprise.inner_life.caption }}</p>
       <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {% for sid in C.voices.statements %}
-        {% set s = S["" ~ sid] %}
-        <figure class="gr-card flex flex-col gap-3">
-          <blockquote class="gr-quote flex-grow">“{{ stmtText(s) }}”</blockquote>
-          <figcaption class="gr-counts">#{{ s.id }} · {{ countsLine(s.total) }}</figcaption>
-          {{ stackBar(s.total, "All participants") }}
-        </figure>
+        {% for sid in C.surprise.inner_life.statements %}
+        {{ cardFull(sid) }}
         {% endfor %}
       </div>
-      {% for q in C.panelist_quotes %}
-      {% if not q.pending_permission %}
-      <figure class="gr-card mt-6">
-        <blockquote class="gr-quote">“{{ q.quote }}”</blockquote>
-        <figcaption class="gr-counts mt-2">{{ q.context }}. {{ q.pair_note }}</figcaption>
-      </figure>
-      {% endif %}
-      {% endfor %}
     </div>
   </section>
 
-  {# ---------- 8. statement explorer ---------- #}
-  <section id="explorer" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
-      <h2 class="mb-4">{{ C.explorer.title }}</h2>
-      <p class="gr-prose mb-4">{{ C.explorer.intro }}</p>
-      <div id="gr-filters" class="flex flex-wrap gap-2 mb-4" hidden>
-        <button type="button" class="gr-filter" data-sort="id" data-dir="asc" aria-pressed="true">In order</button>
-        <button type="button" class="gr-filter" data-sort="minagree" data-dir="desc" aria-pressed="false">Most consensus</button>
-        <button type="button" class="gr-filter" data-sort="div" data-dir="desc" aria-pressed="false">Most divisive</button>
-        <button type="button" class="gr-filter" data-sort="passrate" data-dir="desc" aria-pressed="false">Most passed</button>
+  {# ---------- 5. reading these numbers (quiet, stated once) ---------- #}
+  <section id="notes" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2 gr-note">
+      <h2 class="mb-4">{{ C.notes.title }}</h2>
+      <div class="grid gap-6 md:grid-cols-2">
+        {% for note in C.notes.items %}
+        <div>
+          <h3 class="mb-1">{{ note.title }}</h3>
+          <p>{{ note.text }}</p>
+        </div>
+        {% endfor %}
       </div>
-      <div class="gr-table-wrap">
-        <table class="gr-table" id="gr-explorer-table">
-          <thead>
-            <tr>
-              <th scope="col" class="gr-num" data-key="id">#</th>
-              <th scope="col" data-key="text">Statement</th>
-              <th scope="col" class="gr-num" data-key="agrees">Agree</th>
-              <th scope="col" class="gr-num" data-key="disagrees">Disagree</th>
-              <th scope="col" class="gr-num" data-key="passes">Pass</th>
-              <th scope="col" class="gr-num" data-key="ga" title="Group A agree rate"><span class="gr-text-A">A</span>&nbsp;agree</th>
-              <th scope="col" class="gr-num" data-key="gb" title="Group B agree rate"><span class="gr-text-B">B</span>&nbsp;agree</th>
-              <th scope="col" class="gr-num" data-key="gc" title="Group C agree rate"><span class="gr-text-C">C</span>&nbsp;agree</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for key, s in S %}
-            {% if not s.junk and s.text %}
-            <tr
-              data-id="{{ s.id }}"
-              data-agrees="{{ s.total.agrees }}"
-              data-disagrees="{{ s.total.disagrees }}"
-              data-passes="{{ s.total.passes }}"
-              data-passrate="{{ s.pass_rate }}"
-              data-minagree="{{ s.consensus_min_agree_rate if s.consensus_min_agree_rate != null else -1 }}"
-              data-div="{{ s.divisiveness if s.divisiveness != null else -1 }}"
-              data-ga="{{ s.groups.A.agree_rate if s.groups.A.votes > 0 else -1 }}"
-              data-gb="{{ s.groups.B.agree_rate if s.groups.B.votes > 0 else -1 }}"
-              data-gc="{{ s.groups.C.agree_rate if s.groups.C.votes > 0 else -1 }}"
-            >
-              <td class="gr-num">{{ s.id }}</td>
-              <td><span class="gr-stmt-text">{{ stmtText(s) }}</span> {{ sourceBadge(s) }}</td>
-              <td class="gr-num">{{ s.total.agrees }}</td>
-              <td class="gr-num">{{ s.total.disagrees }}</td>
-              <td class="gr-num">{{ s.total.passes }}</td>
-              {% for g in ["A", "B", "C"] %}
-              {% set t = s.groups[g] %}
-              <td class="gr-num{% if t.thin %} gr-cell-thin{% endif %}" title="Group {{ g }}: {{ countsLine(t) }}">{% if t.votes > 0 %}{{ (t.agree_rate * 100) | round }}%{% else %}–{% endif %}{{ thinGlyph(t) }}</td>
-              {% endfor %}
-            </tr>
-            {% endif %}
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-      <p class="gr-counts mt-3">“Most consensus” ranks by the lowest agree rate across groups A/B/C (a statement only ranks high if every group agrees); “most divisive” by the spread of net agreement across groups. Statements with fewer than {{ R.rules.min_group_votes_for_rankings }} votes in any group are unranked and sort last. Three non-substantive entries are excluded (“Agree”, a test message, and “Not enough time, sorry”). Four statements submitted in the final minutes are omitted pending the final export.</p>
     </div>
   </section>
 
-  {# ---------- 9. what happens next ---------- #}
+  {# ---------- 6. what happens next ---------- #}
   <section id="next" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
       <h2 class="mb-6">{{ C.pipeline.title }}</h2>
@@ -459,48 +350,63 @@ description: "What would AI governance need to do so that everyone felt seen by 
       <h3 class="mb-2">{{ C.pipeline.principles_title }}</h3>
       <p class="gr-prose mb-6">{{ C.pipeline.principles_intro }}</p>
 
-      {% if QV.status == "final" %}
-      <div class="gr-card mb-8">
-        <h4 class="gr-kicker mb-3">Quadratic vote results — voice credits per principle{% if QV.voters %} ({{ QV.voters }} voters{% if QV.credits_per_voter %}, {{ QV.credits_per_voter }} credits each{% endif %}){% endif %}</h4>
-        <div class="flex flex-col gap-2">
-          {% for p in C.pipeline.principles %}
-          {% set q = QV.byId[p.id] %}
-          <div class="gr-qv-row">
-            <span class="font-bold">{{ p.id }}</span>
-            <span role="img" aria-label="{{ p.id }} {{ p.title }}: {{ q.credits }} credits{% if q.votes != null %}, {{ q.votes }} votes{% endif %}"><span class="gr-qv-fill" style="width: {{ (q.credits / QV.maxCredits * 100) | round(1) }}%"></span></span>
-            <span class="gr-counts">{{ q.credits }} credits{% if q.votes != null %} · {{ q.votes }} votes{% endif %}</span>
-          </div>
-          {% endfor %}
-        </div>
-      </div>
-      {% else %}
-      <div class="gr-card mb-8">
-        <p><strong>Voting opens soon.</strong> {{ C.pipeline.qv_pending_note }}</p>
-      </div>
+      {# QV-results container: the compact list below is the empty state.
+         When qv-results.json flips to status "final", each principle gains a
+         credits bar and the list re-sorts by credits, descending — no
+         restructuring needed. #}
+      {% if QV.status != "final" %}
+      <p class="gr-counts mb-6"><strong class="text-black">Voting opens soon.</strong> {{ C.pipeline.qv_pending_note }}</p>
       {% endif %}
-
-      <div class="grid gap-4 md:grid-cols-2">
-        {% for p in C.pipeline.principles %}
-        <article class="gr-card">
-          <h4 class="font-bold mb-1">{{ p.id }} — {{ p.title }} {% if p.tension %}<span class="gr-badge" style="color: #c53030" title="The deliberation did not resolve this question; the quadratic vote will weigh it.">sits on a live tension</span>{% endif %}</h4>
-          <p class="text-size--1 mb-3">{{ p.text }}</p>
-          <details>
-            <summary><span class="gr-counts">Grounding statements: {% for sid in p.grounding %}[{{ sid }}]{% if not loop.last %} {% endif %}{% endfor %}</span></summary>
-            <div class="flex flex-col gap-3 pb-3">
-              {% for sid in p.grounding %}
-              {% set s = S["" ~ sid] %}
-              <div>
-                <p class="gr-stmt-text text-size--1 mb-1">[{{ s.id }}] “{{ stmtText(s) }}”</p>
-                <p class="gr-counts">{{ countsLine(s.total) }}</p>
-              </div>
-              {% endfor %}
+      <ol class="gr-ballot">
+        {% for q in QV.sorted %}
+        {% set p = C.pipeline.principlesById[q.id] %}
+        <li class="gr-ballot-item">
+          <div class="gr-ballot-head">
+            <h4 class="font-bold">{{ p.id }} — {{ p.title }} {% if p.tension %}<span class="gr-badge" style="color: #c53030" title="The deliberation did not resolve this question; the quadratic vote will weigh it.">sits on a live tension</span>{% endif %}</h4>
+            {% if QV.status == "final" %}
+            <div class="gr-qv-row">
+              <span role="img" aria-label="{{ p.id }} {{ p.title }}: {{ q.credits }} credits{% if q.votes != null %}, {{ q.votes }} votes{% endif %}"><span class="gr-qv-fill" style="width: {{ (q.credits / QV.maxCredits * 100) | round(1) }}%"></span></span>
+              <span class="gr-counts">{{ q.credits }} credits</span>
             </div>
+            {% endif %}
+          </div>
+          <p class="text-size--1 mb-1">{{ p.text }}</p>
+          <details>
+            <summary><span class="gr-counts">Grounded in {% for sid in p.grounding %}[{{ sid }}]{% if not loop.last %} {% endif %}{% endfor %}</span></summary>
+            <ul class="flex flex-col gap-1 pb-3 text-size--2">
+              {% for sid in p.grounding %}
+              <li>{{ refLine(sid) }}</li>
+              {% endfor %}
+            </ul>
           </details>
-        </article>
+        </li>
         {% endfor %}
-      </div>
+      </ol>
+      {% if QV.status == "final" and QV.voters %}
+      <p class="gr-counts mt-2">{{ QV.voters }} voters{% if QV.credits_per_voter %}, {{ QV.credits_per_voter }} credits each{% endif %}.</p>
+      {% endif %}
     </div>
   </section>
+
+  {# ---------- 7. full data ---------- #}
+  <section id="data" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2 gr-card flex flex-col md:flex-row md:items-baseline gap-2 md:gap-8">
+      <a class="underline font-bold" href="/geneva-reflections/data/">{{ C.data_page.link_label }} →</a>
+      <a class="underline text-size--1" href="{{ C.data_page.csv_path }}" download>{{ C.data_page.csv_label }}</a>
+    </div>
+  </section>
+
+  {# ---------- panelist quotes (render only with permission) ---------- #}
+  {% for q in C.panelist_quotes %}
+  {% if not q.pending_permission %}
+  <section class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <figure class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2 gr-card">
+      <blockquote class="gr-quote">“{{ q.quote }}”</blockquote>
+      <figcaption class="gr-counts mt-2">{{ q.context }}. {{ q.pair_note }}</figcaption>
+    </figure>
+  </section>
+  {% endif %}
+  {% endfor %}
 
   {# ---------- page footer ---------- #}
   <section id="about-this-page" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -76,7 +76,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
 
 {# ---------- macros ---------- #}
 
-{% macro thinGlyph(t) %}{% if t.thin %}<span class="gr-thin" title="Thin data: this group's tally rests on fewer than 5 votes">◔<span class="sr-only"> (thin data: fewer than 5 votes in this group)</span></span>{% endif %}{% endmacro %}
+{% macro thinGlyph(t) %}{% if t.thin %}<span class="gr-thin"><span aria-hidden="true">◔</span><span class="sr-only"> (thin)</span></span>{% endif %}{% endmacro %}
 
 {% macro countsLine(t) %}{{ t.agrees }} agree · {{ t.disagrees }} disagree · {{ t.passes }} pass · n={{ t.votes }}{% endmacro %}
 
@@ -126,7 +126,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
 {# full statement card: text, total bar, per-group mini bars #}
 {% macro stmtCard(sid) %}
 {% set s = S["" ~ sid] %}
-<div class="gr-card flex flex-col gap-3">
+<div class="gr-card flex flex-col gap-3" id="s{{ s.id }}">
   <p class="gr-stmt-text">“{{ stmtText(s) }}”</p>
   <div class="flex items-baseline gap-2">
     <span class="gr-counts">#{{ s.id }}</span>
@@ -199,7 +199,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
         <span><span class="gr-swatch" style="background:#1a1a1a"></span>agree</span>
         <span><span class="gr-swatch" style="background:#d9d9d9"></span>pass</span>
         <span><span class="gr-swatch" style="background:repeating-linear-gradient(-45deg,#fff,#fff 3px,#6c6c6c 3px,#6c6c6c 4px)"></span>disagree</span>
-        <span>◔ = fewer than 5 votes in that group</span>
+        <span>◔ = thin data: fewer than 5 votes cast in that group; treat as directional</span>
       </div>
       {% for theme in C.consensus.themes %}
       <details {% if loop.first %}open{% endif %}>
@@ -208,6 +208,9 @@ description: "What would AI governance need to do so that everyone felt seen by 
         </summary>
         <div class="pb-6">
           <p class="gr-prose mb-4">{{ theme.blurb }}</p>
+          {% if theme.cross_refs %}
+          <p class="gr-prose gr-counts mb-4">{% for ref in theme.cross_refs %}<a class="underline" href="#s{{ ref.id }}">{{ ref.label }}</a>{% if not loop.last %} · {% endif %}{% endfor %}</p>
+          {% endif %}
           <div class="grid gap-4 md:grid-cols-2">
             {% for sid in theme.statements %}
             {{ stmtCard(sid) }}
@@ -340,7 +343,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
           <div class="gr-card">
             <p class="gr-counts mb-2">The three most-passed statements (of those seen by at least 10 participants):</p>
             <ul class="flex flex-col gap-2">
-              {% for sid in R.rankings.most_passed.slice(0, 3) %}
+              {% for sid in R.display_rankings.most_passed.slice(0, 3) %}
               {% set s = S["" ~ sid] %}
               <li class="text-size--1">“{{ stmtText(s) }}” <span class="gr-counts">— {{ (s.pass_rate * 100) | round }}% passed ({{ s.total.passes }} of {{ s.total.votes }})</span></li>
               {% endfor %}
@@ -406,7 +409,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
           </thead>
           <tbody>
             {% for key, s in S %}
-            {% if not s.junk %}
+            {% if not s.junk and s.text %}
             <tr
               data-id="{{ s.id }}"
               data-agrees="{{ s.total.agrees }}"
@@ -426,7 +429,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
               <td class="gr-num">{{ s.total.passes }}</td>
               {% for g in ["A", "B", "C"] %}
               {% set t = s.groups[g] %}
-              <td class="gr-num" title="Group {{ g }}: {{ countsLine(t) }}">{% if t.votes > 0 %}{{ (t.agree_rate * 100) | round }}%{% else %}–{% endif %}{{ thinGlyph(t) }}</td>
+              <td class="gr-num{% if t.thin %} gr-cell-thin{% endif %}" title="Group {{ g }}: {{ countsLine(t) }}">{% if t.votes > 0 %}{{ (t.agree_rate * 100) | round }}%{% else %}–{% endif %}{{ thinGlyph(t) }}</td>
               {% endfor %}
             </tr>
             {% endif %}
@@ -434,7 +437,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
           </tbody>
         </table>
       </div>
-      <p class="gr-counts mt-3">“Most consensus” ranks by the lowest agree rate across groups A/B/C (a statement only ranks high if every group agrees); “most divisive” by the spread of net agreement across groups. Statements with fewer than {{ R.rules.min_group_votes_for_rankings }} votes in any group are unranked and sort last. Three junk statements ({{ R.rules.junk_ids | join(", ") }}) are excluded.</p>
+      <p class="gr-counts mt-3">“Most consensus” ranks by the lowest agree rate across groups A/B/C (a statement only ranks high if every group agrees); “most divisive” by the spread of net agreement across groups. Statements with fewer than {{ R.rules.min_group_votes_for_rankings }} votes in any group are unranked and sort last. Three non-substantive entries are excluded (“Agree”, a test message, and “Not enough time, sorry”). Four statements submitted in the final minutes are omitted pending the final export.</p>
     </div>
   </section>
 


### PR DESCRIPTION
Revises the live /geneva-reflections page from an analyst's full workup into a three-tier read, per the revision brief. Three commits, one per priority, so P0 can ship independently if needed.

## P0 — bugs and tone (eeacc85)
- Statements 79–82 (votes in the matrix, text missing from the current export — **final export not yet available**) no longer render placeholder rows; one footnote notes the omission. When the final export lands, `analyze.py` + rebuild reinstates them with no code edits.
- "junk entries" → "non-substantive entries ('Agree', a test message, and 'Not enough time, sorry')". Remaining instances of the word are one participant's verbatim statement ("AI is like junk food…") and quotes of it, protected by the preserve-statements-exactly rule.
- Statement [6] cards once (Data, consent & surveillance); Community authorship references it via anchor link.
- Thin-data marker is the bare ◔ everywhere, defined by a single legend line; affected table cells are greyed.

## P1 — tiered restructure (592e5da)
- **Tier 1** (no interaction): six themes as demand sentence + one exemplar card + one `% agree (x/n)` figure · group portraits as visible paragraphs · the [9] divide · the bridging findings (strange bedfellows + inner-life splits) promoted to a styled centerpiece · pipeline + compact ballot.
- **Tier 2** (collapsed `<details>`): supporting statements, signature cards, divide detail, and the pass-interpretation / honest-limits notes as one quiet "Reading these numbers" block (honest-limits text restored here per the brief — it had been removed from the page earlier).
- **Tier 3**: full table at `/geneva-reflections/data/` + statement-level CSV downloadable from both pages. The CSV is the aggregate written by `analyze.py` — the raw participant-votes export stays unpublished (participant-level rows; public repo).
- **Render-once**: each statement has exactly one card, assigned in `content.json`; the build **fails** if a statement is assigned two cards. All other mentions are anchor-linked references.
- **One number language**: `% agree (x/n)` + the tricolor stacked bar only; net-agreement scores and tally strings removed from visible copy (full tallies in tooltips/aria).
- **QV container**: the ballot list is the empty state; flipping `qv-results.json` to `final` renders per-principle credit bars sorted descending — verified with a mocked file, then restored to pending.

## P2 — mobile + accessibility (ad97935)
No overflow at 375px with all expanders open on either page; table scrolls in its own wrapper; thin-cell contrast fixed to AA. Lighthouse mobile (local, gzip): main 97 perf / 100 a11y, data page 95 / 100.

All nine acceptance checks in the brief verified against the built output. Data architecture unchanged: CSVs → `analyze.py` → `results.json` (+ `content.json`, `qv-results.json`) → templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)