### PR TITLE
Geneva Reflections: annotated revisions + clearer narrative structure

### DIFF
--- a/site-data/content.json
+++ b/site-data/content.json
@@ -14,19 +14,16 @@
       { "name": "Sikh LGBT+ Inclusion", "url": null },
       { "name": "RadicalxChange Foundation", "url": "https://www.radicalxchange.org" },
       { "name": "Free Community Church", "url": "https://www.fcc.org.sg" }
-    ],
-    "promise": "Here is what a room spanning four continents — faith leaders, peacebuilders, technologists — agreed on, disagreed about, and asked of AI governance."
+    ]
   },
   "stats": {
-    "continents_display": "4+",
-    "anonymity_note": "Pol.is deliberation is anonymous by design: statements are published verbatim with no names attached, and no vote can be traced to a person."
+    "continents_display": "4+"
   },
   "video": {
     "youtube_id": "Rj419GhtAG4",
     "url": "https://youtu.be/Rj419GhtAG4",
     "title": "Watch the session recording",
-    "caption": "Lived-experience testimony from faith leaders in the UK, Singapore, and the US, then the live deliberation behind the results below.",
-    "privacy_note": "Plays in YouTube's privacy-enhanced mode; nothing loads from YouTube until you press play."
+    "caption": "Lived-experience testimony from faith leaders in the UK, Singapore, and the US, then the live deliberation behind the results below."
   },
   "legend_note": "◔ = thin data: fewer than 5 votes cast in that group; treat as directional.",
   "consensus": {

--- a/site-data/content.json
+++ b/site-data/content.json
@@ -27,8 +27,9 @@
   },
   "legend_note": "◔ = thin data: fewer than 5 votes cast in that group; treat as directional.",
   "consensus": {
+    "kicker": "01 · The common ground",
     "title": "What the room agreed on",
-    "intro": "Across every opinion group, six demands drew broad agreement. Each is shown with one statement in participants' own words — expand a theme for its supporting statements and each group's numbers.",
+    "intro": "Start with the agreements: across every opinion group, six demands drew broad support. Each is shown with one statement in participants' own words — expand a theme for its supporting statements and each group's numbers. The groups behind these votes, and where they part ways, come next.",
     "themes": [
       {
         "title": "Contestability & accountability",
@@ -72,27 +73,29 @@
     ]
   },
   "groups": {
+    "kicker": "02 · The people behind the votes",
     "title": "Three ways of seeing",
     "intro": "Pol.is clusters participants by how they voted, not who they are. Three distinct ways of seeing the question emerged. These are positions, not caricatures — each is a coherent answer to what being “seen” by AI should mean.",
+    "evidence_label": "Supporting evidence",
     "list": [
       {
         "key": "A",
         "name": "Boundary Keepers",
-        "sketch": "Locates the remedy in limits on AI's reach: it isn't AI's job to reflect every culture's values [9]; some questions should only ever be answered by a person [13]; they do not want to feel “seen” by AI [23] and are drawn to statements of loss — the friend who talks more to AI than to them [30], AI as “junk food” [55]. The room's heavy passers: their abstentions cluster on statements about lived experience of misrepresentation, reading as distance from the experience rather than opposition to the agenda.",
+        "sketch": "Wants clear limits on where AI belongs. For this group the remedy is boundaries: some questions should only ever be answered by a person, and being deeply known by a machine reads as a loss, not a comfort. They abstained most often on statements about being misrepresented by AI — distance from that experience, not opposition to fixing it.",
         "cards": [],
         "references": [9, 13, 23, 30, 55]
       },
       {
         "key": "B",
         "name": "Hands-On Optimists",
-        "sketch": "The only group at ease with AI in intimate territory — unanimous that AI has a role in spirituality [33 rejected 0/5], open to AI as moral interlocutor [12] and to the personalization trade-off [4] — yet the strongest voices for building AI bottom-up [24] and for governance reform [11], [20]. Remedy: agency through building and using. (Fewest votes cast per member; their tallies on late statements are thin.)",
+        "sketch": "Comfortable letting AI into intimate territory — the only group open to AI in spiritual and moral life — and at the same time the strongest voices for changing how AI is governed and built. Their remedy is agency: build it bottom-up, shape it by using it. The smallest group and the lightest voters, so their numbers are the thinnest.",
         "cards": [24, 11],
         "references": [33, 4, 12, 20]
       },
       {
         "key": "C",
         "name": "Recognition Seekers",
-        "sketch": "Defined by the experience of misrecognition — “AI talks about my faith or culture like an outsider describing it” [0] — and the demand that this is AI's problem to fix (the sharpest rejection in the event: [9]). Wants recognition without capture: near-unanimous against manipulation [5], against moral outsourcing [12] and the privacy trade-off [4], while the most enthusiastic group for community-built AI [15], [3].",
+        "sketch": "Knows what it feels like when AI describes their faith or culture like an outsider — and insists that fixing this is AI's job, not theirs. They want recognition without capture: firmly against manipulation and privacy trade-offs, and the most enthusiastic about communities building AI on their own terms.",
         "cards": [0],
         "references": [9, 5, 15, 3]
       }
@@ -100,32 +103,31 @@
     "disclosure": "A fourth cluster, Group D, contains a single participant and cannot be characterized without identifying them; their votes count in the room-wide totals but not in group-level analysis. Two participants voted too few times to be clustered at all. Group A includes the facilitation account used to seed the first twenty statements; it cast only pass votes."
   },
   "split": {
+    "kicker": "03 · The deepest divide",
     "title": "Where it genuinely split",
     "lead": "“It isn't AI's job to reflect every culture's values” is the room's cleanest divide: the Boundary Keepers' most-agreed position and the Recognition Seekers' sharpest rejection. Universality versus representation is a real disagreement, not a misunderstanding — and it survives into the draft principles below.",
-    "statement": 9,
-    "expander_title": "More on the divides",
-    "resolved": {
-      "title": "A tension the room resolved",
-      "blurb": "Personalization versus protection looked like a dilemma — until the votes came in. The claim that AI knowing you personally is worth the privacy cost [4] was rejected by every group but one, while anti-dependency design came as close to consensus as anything in the event, including among the personalization-friendly group. The room wants AI that understands without a licence to capture.",
-      "statement": 4,
-      "cross_refs": [
-        { "id": 16, "label": "The anti-dependency statement [16] sits under Protection from dependency & manipulation above" }
-      ]
-    }
+    "statement": 9
   },
   "surprise": {
-    "kicker": "The finding a standard poll would miss",
+    "kicker": "04 · The findings a standard poll would miss",
     "title": "The surprise",
-    "intro": "A standard opinion report stops at what separates the groups. The most consequential findings here run the other way: an agreement that joins the two groups most opposed elsewhere, and a question that splits groups from within. This is what bridging analysis is for — and it is the method's case for the quadratic vote that follows.",
+    "intro": "A standard opinion report stops at what separates the groups. The two most consequential findings here run the other way — an agreement that joins the two groups most opposed elsewhere, and a question that splits every group from within. Together they explain why this process doesn't end at a poll: they are exactly what the quadratic vote is built to weigh.",
     "bedfellows": {
+      "finding_label": "Finding one — an unexpected alliance",
       "title": "Strange bedfellows",
-      "caption": "The two groups most opposed on whether AI should reflect every culture's values agree completely on something else: they do not want AI to know them intimately. Six members of one and ten of the other affirmed “I don't want to feel seen by AI” — against the one group that welcomes that closeness. Bridging analysis exists to find agreements like this: consensus that crosses the room's main divide from an unexpected direction.",
+      "caption": "Boundary Keepers and Recognition Seekers disagree about almost everything above — most of all about whose job it is to reflect a culture's values. But on one thing they speak with a single voice: they do not want AI to know them intimately. “I don't want to feel seen by AI” carried both groups decisively, against the one group that welcomes that closeness.",
+      "reading": "How to read the cards: in each one, groups A and C — the rivals of the divide above — lean the same way, while B stands apart. That inversion of the room's main fault line is the finding.",
+      "takeaway": "This is the room's hidden second consensus: whatever else AI becomes, the right not to be intimately known by it must be protected. It enters the ballot below as",
+      "takeaway_link_label": "P10 — the right not to be seen",
       "statements": [23, 30, 55],
-      "cross_ref_note": "The same two groups sit at opposite poles of the divide above — Boundary Keepers embracing, Recognition Seekers rejecting, statement [9] — and of Group C's defining experience, statement [0]."
+      "cross_ref_note": "The divide these two groups are known for:"
     },
     "inner_life": {
+      "finding_label": "Finding two — the divide inside every group",
       "title": "The question that splits every group",
-      "caption": "Whether AI belongs in the inner and spiritual life — as a deepener of tradition, a moral interlocutor, or not at all — split two of the three groups down the middle. This tension runs through communities, not between them, and it is exactly the kind of question the next stage (quadratic voting) is designed to weigh.",
+      "caption": "Whether AI belongs in the inner and spiritual life — as a deepener of tradition, a moral interlocutor, or not at all — is not a fight between the groups. It runs through them: members of the same group, who vote together on nearly everything else, part ways here.",
+      "reading": "How to read the cards: the bars below are within each group. Where a group's bar shows both solid (agree) and striped (disagree) in near-equal measure, that group is divided against itself.",
+      "takeaway": "No group can settle this question for the room, because no group has settled it for itself. This is precisely the kind of tension the quadratic vote is designed to weigh — person by person, not bloc by bloc.",
       "statements": [1, 12, 33, 43]
     }
   },
@@ -151,6 +153,7 @@
     "omitted_note": "Four statements submitted in the final minutes are omitted pending the final export."
   },
   "pipeline": {
+    "kicker": "05 · From results to principles",
     "title": "What happens next",
     "steps": [
       {

--- a/site-data/content.json
+++ b/site-data/content.json
@@ -117,7 +117,7 @@
       "title": "Strange bedfellows",
       "caption": "Boundary Keepers and Recognition Seekers disagree about almost everything above — most of all about whose job it is to reflect a culture's values. But on one thing they speak with a single voice: they do not want AI to know them intimately. “I don't want to feel seen by AI” carried both groups decisively, against the one group that welcomes that closeness.",
       "reading": "How to read the cards: in each one, groups A and C — the rivals of the divide above — lean the same way, while B stands apart. That inversion of the room's main fault line is the finding.",
-      "takeaway": "This is the room's hidden second consensus: whatever else AI becomes, the right not to be intimately known by it must be protected. It enters the ballot below as",
+      "takeaway": "This is the room's hidden second consensus: whatever else AI becomes, the right not to be intimately known by it must be protected. It surfaces in the draft ideas below as",
       "takeaway_link_label": "P10 — the right not to be seen",
       "statements": [23, 30, 55],
       "cross_ref_note": "The divide these two groups are known for:"
@@ -163,7 +163,7 @@
       },
       {
         "label": "Reflections Working Group",
-        "detail": "Participants refine the draft principles below into a final ballot.",
+        "detail": "Where we are now: participants are making sense of these results together and distilling them into ballot items.",
         "status": "current"
       },
       {
@@ -178,9 +178,10 @@
       }
     ],
     "qv_explainer": "Quadratic voting measures how much people care, not just what they prefer. Each voter gets the same budget of credits; one vote for a principle costs 1 credit, two votes cost 4, three cost 9. Spreading credits is cheap, piling them on one priority is expensive — so the results reveal intensity honestly.",
-    "qv_pending_note": "The quadratic vote is not yet open. Once it closes, the results — credits allocated per principle — will appear here.",
-    "principles_title": "The draft ballot: ten principles",
-    "principles_intro": "Drafted from the deliberation record by the conveners, for the Reflections Working Group to refine. Expand a principle to see the statements that ground it. Two principles sit on live tensions the room did not resolve; the quadratic vote will weigh them.",
+    "qv_pending_note": "The quadratic vote opens once the Reflections Working Group has settled the ballot. When it closes, the results — credits allocated per item — will appear here.",
+    "principles_title": "Ten ideas for ballot items",
+    "principles_intro": "These are starting points, not a finished ballot: readings of the deliberation record, distilled into the kind of principles the room seemed to be asking for. The Reflections Working Group is making sense of the Pol.is results now, and these ideas are theirs to challenge, rewrite, merge, or replace — each one cites the statements it is drawn from, so the drafting can be checked against the votes. Two sit on live tensions the room did not resolve; if they survive revision, the quadratic vote will weigh them.",
+    "feedback_ask": "If you took part in the event: do these ideas capture what you said — and what did we miss? Tell us which to keep, rework, or drop.",
     "principles": [
       { "id": "P1", "title": "Contestability", "text": "Guarantee communities a binding, resourced channel to challenge how an AI system represents their tradition and to get errors fixed.", "grounding": [2, 10, 45], "tension": false },
       { "id": "P2", "title": "Answerability of value-setters", "text": "Make whoever sets an AI system's values legally accountable, through enforceable regulation, to the people affected.", "grounding": [10, 21, 20], "tension": false },

--- a/src/site/_data/geneva.js
+++ b/src/site/_data/geneva.js
@@ -48,7 +48,7 @@ module.exports = () => {
   });
   content.groups.list.forEach((g) => (g.cards || []).forEach(claim));
   claim(content.split.statement);
-  claim(content.split.resolved.statement);
+  if (content.split.resolved) claim(content.split.resolved.statement);
   content.surprise.bedfellows.statements.forEach(claim);
   content.surprise.inner_life.statements.forEach(claim);
   content.carded = carded;

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -62,12 +62,7 @@
 }
 @media (min-width: 640px) {
   .geneva .gr-stats {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-@media (min-width: 1024px) {
-  .geneva .gr-stats {
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 .geneva .gr-stat {

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -387,6 +387,21 @@
   background: #1a1a1a;
 }
 
+/* compact consensus themes: the section should scan, not sprawl */
+.geneva .gr-theme h3 {
+  font-size: var(--step--1);
+}
+.geneva .gr-theme > p {
+  font-size: var(--step--2);
+}
+.geneva .gr-theme .gr-card {
+  padding: 0.75rem;
+  gap: 0.5rem;
+}
+.geneva .gr-theme .gr-stmt-text {
+  font-size: var(--step--1);
+}
+
 /* the centerpiece section */
 .geneva .gr-feature {
   border-top: 6px solid #1a1a1a;

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -340,7 +340,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
          credits bar and the list re-sorts by credits, descending — no
          restructuring needed. #}
       {% if QV.status != "final" %}
-      <p class="gr-counts mb-6"><strong class="text-black">Voting opens soon.</strong> {{ C.pipeline.qv_pending_note }}</p>
+      <p class="gr-counts mb-6"><strong class="text-black">The ballot is still taking shape.</strong> {{ C.pipeline.qv_pending_note }}</p>
       {% endif %}
       <ol class="gr-ballot">
         {% for q in QV.sorted %}
@@ -369,6 +369,9 @@ description: "What would AI governance need to do so that everyone felt seen by 
       </ol>
       {% if QV.status == "final" and QV.voters %}
       <p class="gr-counts mt-2">{{ QV.voters }} voters{% if QV.credits_per_voter %}, {{ QV.credits_per_voter }} credits each{% endif %}.</p>
+      {% endif %}
+      {% if QV.status != "final" %}
+      <p class="gr-prose text-size--1 mt-8"><strong>{{ C.pipeline.feedback_ask }}</strong> Share your revisions through the <a class="underline" href="{{ C.footer.rwg_signup_url }}">Reflections Working Group</a>{% if C.footer.contact_email %} or write to <a class="underline" href="mailto:{{ C.footer.contact_email }}">{{ C.footer.contact_email }}</a>{% endif %}.</p>
       {% endif %}
     </div>
   </section>

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -154,32 +154,27 @@ description: "What would AI governance need to do so that everyone felt seen by 
 
 <main class="geneva">
 
-  {# ---------- hero (unchanged) ---------- #}
+  {# ---------- hero ---------- #}
   <header class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pt-12 lg:pt-16 pb-8">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
       <p class="gr-kicker mb-4">{{ C.hero.event_name }} · {{ C.hero.event_date }}</p>
-      <h1 class="gr-hero-question mb-6">“{{ C.hero.question }}”</h1>
       <p class="gr-prose mb-2">{{ C.hero.official_line }}, convened by
         {%- for cv in C.hero.conveners %}
         {% if cv.url %}<a class="underline" href="{{ cv.url }}">{{ cv.name }}</a>{% else %}{{ cv.name }}{% endif %}{% if not loop.last %},{% endif %}
         {%- endfor %}.
       </p>
-      <p class="gr-prose font-bold text-size-1">{{ C.hero.promise }}</p>
     </div>
   </header>
 
-  {# ---------- stats bar (unchanged) ---------- #}
+  {# ---------- stats bar ---------- #}
   <section aria-label="Participation at a glance" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-12">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
       <div class="gr-stats">
         <div class="gr-stat"><span class="gr-stat-number">{{ P.participants }}</span><span class="gr-stat-label">participants</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ P.total_votes_display }}</span><span class="gr-stat-label">votes cast</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ P.total_statements }}</span><span class="gr-stat-label">statements</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ (P.live_share * 100) | round }}%</span><span class="gr-stat-label">of statements written live by participants ({{ P.live_statements }} of {{ P.total_statements }})</span></div>
         <div class="gr-stat"><span class="gr-stat-number">{{ C.stats.continents_display }}</span><span class="gr-stat-label">continents</span></div>
+        <div class="gr-stat"><span class="gr-stat-number">{{ P.total_statements }}</span><span class="gr-stat-label">statements</span></div>
         <div class="gr-stat"><span class="gr-stat-number">{{ P.opinion_groups }}</span><span class="gr-stat-label">opinion groups found</span></div>
       </div>
-      <p class="gr-counts mt-2">{{ C.stats.anonymity_note }}</p>
     </div>
   </section>
 
@@ -193,10 +188,17 @@ description: "What would AI governance need to do so that everyone felt seen by 
           <span class="gr-video-label">{{ C.video.title }}</span>
         </a>
       </div>
-      <p class="gr-counts mt-2">{{ C.video.caption }} {{ C.video.privacy_note }}</p>
+      <p class="gr-counts mt-2">{{ C.video.caption }}</p>
     </div>
   </section>
   {% endif %}
+
+  {# ---------- the question ---------- #}
+  <section aria-label="The deliberation question" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
+      <h1 class="gr-hero-question">“{{ C.hero.question }}”</h1>
+    </div>
+  </section>
 
   {# ---------- 1. what the room agreed on ---------- #}
   <section id="agreed" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -203,6 +203,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
   {# ---------- 1. what the room agreed on ---------- #}
   <section id="agreed" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
+      <p class="gr-kicker mb-2">{{ C.consensus.kicker }}</p>
       <h2 class="mb-4">{{ C.consensus.title }}</h2>
       <p class="gr-prose mb-4">{{ C.consensus.intro }}</p>
       <div class="gr-legend mb-8">
@@ -210,7 +211,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
         <span><span class="gr-swatch" style="background:#d9d9d9"></span>pass</span>
         <span><span class="gr-swatch" style="background:repeating-linear-gradient(-45deg,#fff,#fff 3px,#6c6c6c 3px,#6c6c6c 4px)"></span>disagree</span>
       </div>
-      <div class="grid gap-x-8 gap-y-10 md:grid-cols-2 xl:grid-cols-3">
+      <div class="grid gap-x-8 gap-y-8 md:grid-cols-2 lg:grid-cols-3">
         {% for theme in C.consensus.themes %}
         <div class="gr-theme">
           <h3 class="mb-2">{{ theme.title }}</h3>
@@ -240,6 +241,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
   {# ---------- 2. the three groups (portraits visible, cards collapsed) ---------- #}
   <section id="groups" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
+      <p class="gr-kicker mb-2">{{ C.groups.kicker }}</p>
       <h2 class="mb-4">{{ C.groups.title }}</h2>
       <p class="gr-prose mb-8">{{ C.groups.intro }}</p>
       <div class="gr-groups">
@@ -249,7 +251,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
           <p class="gr-counts mb-3">{{ P.group_sizes[grp.key] }} participants</p>
           <p class="text-size--1 mb-3">{{ grp.sketch }}</p>
           <details>
-            <summary><span class="gr-counts">Signature statements</span></summary>
+            <summary><span class="gr-counts">{{ C.groups.evidence_label }}</span></summary>
             <div class="flex flex-col gap-4 pb-4">
               {% for sid in grp.cards %}
               {{ cardFull(sid) }}
@@ -273,19 +275,9 @@ description: "What would AI governance need to do so that everyone felt seen by 
   {# ---------- 3. where it genuinely split ---------- #}
   <section id="split" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-6 mb-6 lg:mb-0">
+      <p class="gr-kicker mb-2">{{ C.split.kicker }}</p>
       <h2 class="mb-4">{{ C.split.title }}</h2>
       <p class="gr-prose mb-4">{{ C.split.lead }}</p>
-      <details>
-        <summary><span class="gr-counts">{{ C.split.expander_title }}</span></summary>
-        <div class="flex flex-col gap-4 pb-4">
-          <h3>{{ C.split.resolved.title }}</h3>
-          <p class="text-size--1">{{ C.split.resolved.blurb }}</p>
-          {{ cardFull(C.split.resolved.statement) }}
-          {% if C.split.resolved.cross_refs %}
-          <p class="gr-counts">{% for ref in C.split.resolved.cross_refs %}<a class="underline" href="#s{{ ref.id }}">{{ ref.label }}</a>{% if not loop.last %} · {% endif %}{% endfor %}</p>
-          {% endif %}
-        </div>
-      </details>
     </div>
     <div class="col-span-columns lg:col-start-column-7 lg:col-end-margin-2">
       {{ cardFull(C.split.statement) }}
@@ -299,28 +291,35 @@ description: "What would AI governance need to do so that everyone felt seen by 
       <h2 class="mb-4">{{ C.surprise.title }}</h2>
       <p class="gr-prose mb-10">{{ C.surprise.intro }}</p>
 
+      <p class="gr-kicker mb-1">{{ C.surprise.bedfellows.finding_label }}</p>
       <h3 class="mb-2">{{ C.surprise.bedfellows.title }}</h3>
-      <p class="gr-prose mb-2">{{ C.surprise.bedfellows.caption }}</p>
+      <p class="gr-prose mb-3">{{ C.surprise.bedfellows.caption }}</p>
+      <p class="gr-prose text-size--1 mb-2"><em>{{ C.surprise.bedfellows.reading }}</em></p>
       <p class="gr-counts gr-prose mb-6">{{ C.surprise.bedfellows.cross_ref_note }} {% for sid in [9, 0] %}{{ refLine(sid) }}{% if not loop.last %} · {% endif %}{% endfor %}</p>
-      <div class="grid gap-4 md:grid-cols-3 mb-12">
+      <div class="grid gap-4 md:grid-cols-3 mb-4">
         {% for sid in C.surprise.bedfellows.statements %}
         {{ cardFull(sid) }}
         {% endfor %}
       </div>
+      <p class="gr-prose font-bold text-size--1 mb-12">{{ C.surprise.bedfellows.takeaway }} <a class="underline" href="#next">{{ C.surprise.bedfellows.takeaway_link_label }}</a>.</p>
 
+      <p class="gr-kicker mb-1">{{ C.surprise.inner_life.finding_label }}</p>
       <h3 class="mb-2">{{ C.surprise.inner_life.title }}</h3>
-      <p class="gr-prose mb-6">{{ C.surprise.inner_life.caption }}</p>
-      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <p class="gr-prose mb-3">{{ C.surprise.inner_life.caption }}</p>
+      <p class="gr-prose text-size--1 mb-6"><em>{{ C.surprise.inner_life.reading }}</em></p>
+      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4 mb-4">
         {% for sid in C.surprise.inner_life.statements %}
         {{ cardFull(sid) }}
         {% endfor %}
       </div>
+      <p class="gr-prose font-bold text-size--1">{{ C.surprise.inner_life.takeaway }}</p>
     </div>
   </section>
 
   {# ---------- 5. what happens next ---------- #}
   <section id="next" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
+      <p class="gr-kicker mb-2">{{ C.pipeline.kicker }}</p>
       <h2 class="mb-6">{{ C.pipeline.title }}</h2>
       <ol class="gr-pipeline mb-4">
         {% for step in C.pipeline.steps %}

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -209,7 +209,6 @@ description: "What would AI governance need to do so that everyone felt seen by 
         <span><span class="gr-swatch" style="background:#1a1a1a"></span>agree</span>
         <span><span class="gr-swatch" style="background:#d9d9d9"></span>pass</span>
         <span><span class="gr-swatch" style="background:repeating-linear-gradient(-45deg,#fff,#fff 3px,#6c6c6c 3px,#6c6c6c 4px)"></span>disagree</span>
-        <span>{{ C.legend_note }}</span>
       </div>
       <div class="grid gap-x-8 gap-y-10 md:grid-cols-2 xl:grid-cols-3">
         {% for theme in C.consensus.themes %}
@@ -319,22 +318,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
     </div>
   </section>
 
-  {# ---------- 5. reading these numbers (quiet, stated once) ---------- #}
-  <section id="notes" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2 gr-note">
-      <h2 class="mb-4">{{ C.notes.title }}</h2>
-      <div class="grid gap-6 md:grid-cols-2">
-        {% for note in C.notes.items %}
-        <div>
-          <h3 class="mb-1">{{ note.title }}</h3>
-          <p>{{ note.text }}</p>
-        </div>
-        {% endfor %}
-      </div>
-    </div>
-  </section>
-
-  {# ---------- 6. what happens next ---------- #}
+  {# ---------- 5. what happens next ---------- #}
   <section id="next" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
       <h2 class="mb-6">{{ C.pipeline.title }}</h2>


### PR DESCRIPTION
Follow-up to #242. Three commits:

**Hero & stats (`ce32874`)** — question moves below the video; promise line removed; stats bar reduced to four tiles (participants · continents · statements · opinion groups); anonymity note and video privacy sentence removed.

**Caveat presentation (`3d31da6`)** — thin-data legend line off the main page (definition stays on /geneva-reflections/data/); "Reading these numbers" section removed (texts preserved unrendered in content.json).

**Narrative structure (`dd99a1d`)** — per review of the page flow:
- Numbered narrative spine (01 common ground → 02 the groups → 03 the deepest divide → 04 the cross-cutting findings → 05 what happens next)
- Common ground compacted to a three-column grid with smaller exemplar cards so it scans instead of sprawling
- Group portraits rewritten plainly — no statement ids or tallies in the visible text; the evidence lives in a "Supporting evidence" expander under each portrait
- The hidden personalization-vs-protection expander is removed from "Where it genuinely split"
- The two cross-cutting findings gain sense-making narrative: "Finding one / two" framing, a how-to-read line per exhibit, and takeaway lines (strange bedfellows links its conclusion to ballot principle P10)

Render-once rule still enforced at build time; all numbers still trace to results.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)