### PR TITLE
Geneva Reflections: masthead and video/stats band at the top

### DIFF
--- a/site-data/content.json
+++ b/site-data/content.json
@@ -5,8 +5,10 @@
     "description": "What would AI governance need to do so that everyone felt seen by AI? Results of the Pol.is deliberation from “Can AI See Me?”, an official virtual side event of the first UN Global Dialogue on AI Governance, and the road to the Geneva Reflection Principles."
   },
   "hero": {
+    "title": "Can AI See Me?",
+    "subtitle": "Human Dignity, Identity, and Moral Agency in Global AI Governance",
     "question": "What would AI governance need to do so that everyone here felt seen by AI?",
-    "event_name": "Can AI See Me? Human Dignity, Identity, and Moral Agency in Global AI Governance",
+    "question_kicker": "The question put to the room",
     "event_date": "6 July 2026",
     "official_line": "An official virtual side event of the first UN Global Dialogue on AI Governance",
     "conveners": [

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -41,7 +41,14 @@
   max-width: 46em;
 }
 
-/* ---- hero ---------------------------------------------------------- */
+/* ---- masthead & question ------------------------------------------- */
+
+.geneva .gr-masthead {
+  font-family: Messer, sans-serif;
+  text-transform: uppercase;
+  font-size: clamp(2.4rem, 5.5vw, 4rem);
+  line-height: 0.98;
+}
 
 .geneva .gr-hero-question {
   font-family: Messer, sans-serif;
@@ -63,6 +70,14 @@
 @media (min-width: 640px) {
   .geneva .gr-stats {
     grid-template-columns: repeat(4, 1fr);
+  }
+}
+/* stats stacked in a column beside the video */
+@media (min-width: 768px) {
+  .geneva .gr-stats-col {
+    grid-template-columns: 1fr;
+    grid-auto-rows: 1fr;
+    height: 100%;
   }
 }
 .geneva .gr-stat {

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -154,11 +154,12 @@ description: "What would AI governance need to do so that everyone felt seen by 
 
 <main class="geneva">
 
-  {# ---------- hero ---------- #}
-  <header class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pt-12 lg:pt-16 pb-8">
+  {# ---------- masthead ---------- #}
+  <header class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pt-12 lg:pt-16 pb-10">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
-      <p class="gr-kicker mb-4">{{ C.hero.event_name }} · {{ C.hero.event_date }}</p>
-      <p class="gr-prose mb-2">{{ C.hero.official_line }}, convened by
+      <h1 class="gr-masthead mb-2">{{ C.hero.title }}</h1>
+      <p class="gr-kicker mb-3">{{ C.hero.subtitle }} · {{ C.hero.event_date }}</p>
+      <p class="gr-counts gr-prose">{{ C.hero.official_line }}, convened by
         {%- for cv in C.hero.conveners %}
         {% if cv.url %}<a class="underline" href="{{ cv.url }}">{{ cv.name }}</a>{% else %}{{ cv.name }}{% endif %}{% if not loop.last %},{% endif %}
         {%- endfor %}.
@@ -166,22 +167,10 @@ description: "What would AI governance need to do so that everyone felt seen by 
     </div>
   </header>
 
-  {# ---------- stats bar ---------- #}
-  <section aria-label="Participation at a glance" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-12">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
-      <div class="gr-stats">
-        <div class="gr-stat"><span class="gr-stat-number">{{ P.participants }}</span><span class="gr-stat-label">participants</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ C.stats.continents_display }}</span><span class="gr-stat-label">continents</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ P.total_statements }}</span><span class="gr-stat-label">statements</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ P.opinion_groups }}</span><span class="gr-stat-label">opinion groups found</span></div>
-      </div>
-    </div>
-  </section>
-
-  {# ---------- session recording ---------- #}
-  {% if C.video %}
-  <section id="recording" aria-label="Session recording" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-3 lg:col-end-gutter-11">
+  {# ---------- session recording + participation band ---------- #}
+  <section id="recording" aria-label="Session recording and participation" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    {% if C.video %}
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-8 mb-6 lg:mb-0">
       <div class="gr-video" data-youtube-id="{{ C.video.youtube_id }}">
         <a class="gr-video-facade" href="{{ C.video.url }}">
           <span class="gr-video-play" aria-hidden="true"></span>
@@ -190,13 +179,25 @@ description: "What would AI governance need to do so that everyone felt seen by 
       </div>
       <p class="gr-counts mt-2">{{ C.video.caption }}</p>
     </div>
+    <div class="col-span-columns lg:col-start-column-9 lg:col-end-margin-2">
+      <div class="gr-stats gr-stats-col">
+    {% else %}
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
+      <div class="gr-stats">
+    {% endif %}
+        <div class="gr-stat"><span class="gr-stat-number">{{ P.participants }}</span><span class="gr-stat-label">participants</span></div>
+        <div class="gr-stat"><span class="gr-stat-number">{{ C.stats.continents_display }}</span><span class="gr-stat-label">continents</span></div>
+        <div class="gr-stat"><span class="gr-stat-number">{{ P.total_statements }}</span><span class="gr-stat-label">statements</span></div>
+        <div class="gr-stat"><span class="gr-stat-number">{{ P.opinion_groups }}</span><span class="gr-stat-label">opinion groups found</span></div>
+      </div>
+    </div>
   </section>
-  {% endif %}
 
   {# ---------- the question ---------- #}
   <section aria-label="The deliberation question" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
-      <h1 class="gr-hero-question">“{{ C.hero.question }}”</h1>
+      <p class="gr-kicker mb-2">{{ C.hero.question_kicker }}</p>
+      <p class="gr-hero-question">“{{ C.hero.question }}”</p>
     </div>
   </section>
 


### PR DESCRIPTION
Follow-up to #243 carrying the top-of-page layout rework that landed after that merge.

- **Masthead**: "Can AI See Me?" becomes the visible page `h1` in the display face, with the subtitle + date as a kicker line and the conveners/official line demoted to quiet small text (links intact).
- **Video + stats band**: the session recording spans the left two-thirds; the four stat tiles stack in an equal-height column on the right. On mobile the band stacks — video, caption, then the 2×2 stats grid (verified, no overflow at 375px).
- **The question** stays below the video and gains the kicker "The question put to the room", making its role as the gateway into sections 01–05 explicit; it is no longer the page `h1`, so heading hierarchy stays clean.

Grid note for reviewers: in `layout-12`, the named line `gutter N` sits before column N+1, so the video column ends at `gutter-8` to meet the stats at `column-9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)