### PR TITLE
Geneva Reflections: remove the QV ballot items section

### DIFF
--- a/site-data/content.json
+++ b/site-data/content.json
@@ -107,7 +107,7 @@
   "split": {
     "kicker": "03 · The deepest divide",
     "title": "Where it genuinely split",
-    "lead": "“It isn't AI's job to reflect every culture's values” is the room's cleanest divide: the Boundary Keepers' most-agreed position and the Recognition Seekers' sharpest rejection. Universality versus representation is a real disagreement, not a misunderstanding — and it survives into the draft principles below.",
+    "lead": "“It isn't AI's job to reflect every culture's values” is the room's cleanest divide: the Boundary Keepers' most-agreed position and the Recognition Seekers' sharpest rejection. Universality versus representation is a real disagreement, not a misunderstanding.",
     "statement": 9
   },
   "surprise": {
@@ -119,8 +119,7 @@
       "title": "Strange bedfellows",
       "caption": "Boundary Keepers and Recognition Seekers disagree about almost everything above — most of all about whose job it is to reflect a culture's values. But on one thing they speak with a single voice: they do not want AI to know them intimately. “I don't want to feel seen by AI” carried both groups decisively, against the one group that welcomes that closeness.",
       "reading": "How to read the cards: in each one, groups A and C — the rivals of the divide above — lean the same way, while B stands apart. That inversion of the room's main fault line is the finding.",
-      "takeaway": "This is the room's hidden second consensus: whatever else AI becomes, the right not to be intimately known by it must be protected. It surfaces in the draft ideas below as",
-      "takeaway_link_label": "P10 — the right not to be seen",
+      "takeaway": "This is the room's hidden second consensus: whatever else AI becomes, the right not to be intimately known by it must be protected.",
       "statements": [23, 30, 55],
       "cross_ref_note": "The divide these two groups are known for:"
     },

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -306,7 +306,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
         {{ cardFull(sid) }}
         {% endfor %}
       </div>
-      <p class="gr-prose font-bold text-size--1 mb-12">{{ C.surprise.bedfellows.takeaway }} <a class="underline" href="#next">{{ C.surprise.bedfellows.takeaway_link_label }}</a>.</p>
+      <p class="gr-prose font-bold text-size--1 mb-12">{{ C.surprise.bedfellows.takeaway }}</p>
 
       <p class="gr-kicker mb-1">{{ C.surprise.inner_life.finding_label }}</p>
       <h3 class="mb-2">{{ C.surprise.inner_life.title }}</h3>
@@ -335,49 +335,6 @@ description: "What would AI governance need to do so that everyone felt seen by 
         </li>
         {% endfor %}
       </ol>
-      <p class="gr-prose mb-10"><strong>How the vote works:</strong> {{ C.pipeline.qv_explainer }}</p>
-
-      <h3 class="mb-2">{{ C.pipeline.principles_title }}</h3>
-      <p class="gr-prose mb-6">{{ C.pipeline.principles_intro }}</p>
-
-      {# QV-results container: the compact list below is the empty state.
-         When qv-results.json flips to status "final", each principle gains a
-         credits bar and the list re-sorts by credits, descending — no
-         restructuring needed. #}
-      {% if QV.status != "final" %}
-      <p class="gr-counts mb-6"><strong class="text-black">The ballot is still taking shape.</strong> {{ C.pipeline.qv_pending_note }}</p>
-      {% endif %}
-      <ol class="gr-ballot">
-        {% for q in QV.sorted %}
-        {% set p = C.pipeline.principlesById[q.id] %}
-        <li class="gr-ballot-item">
-          <div class="gr-ballot-head">
-            <h4 class="font-bold">{{ p.id }} — {{ p.title }} {% if p.tension %}<span class="gr-badge" style="color: #c53030" title="The deliberation did not resolve this question; the quadratic vote will weigh it.">sits on a live tension</span>{% endif %}</h4>
-            {% if QV.status == "final" %}
-            <div class="gr-qv-row">
-              <span role="img" aria-label="{{ p.id }} {{ p.title }}: {{ q.credits }} credits{% if q.votes != null %}, {{ q.votes }} votes{% endif %}"><span class="gr-qv-fill" style="width: {{ (q.credits / QV.maxCredits * 100) | round(1) }}%"></span></span>
-              <span class="gr-counts">{{ q.credits }} credits</span>
-            </div>
-            {% endif %}
-          </div>
-          <p class="text-size--1 mb-1">{{ p.text }}</p>
-          <details>
-            <summary><span class="gr-counts">Grounded in {% for sid in p.grounding %}[{{ sid }}]{% if not loop.last %} {% endif %}{% endfor %}</span></summary>
-            <ul class="flex flex-col gap-1 pb-3 text-size--2">
-              {% for sid in p.grounding %}
-              <li>{{ refLine(sid) }}</li>
-              {% endfor %}
-            </ul>
-          </details>
-        </li>
-        {% endfor %}
-      </ol>
-      {% if QV.status == "final" and QV.voters %}
-      <p class="gr-counts mt-2">{{ QV.voters }} voters{% if QV.credits_per_voter %}, {{ QV.credits_per_voter }} credits each{% endif %}.</p>
-      {% endif %}
-      {% if QV.status != "final" %}
-      <p class="gr-prose text-size--1 mt-8"><strong>{{ C.pipeline.feedback_ask }}</strong> Share your revisions through the <a class="underline" href="{{ C.footer.rwg_signup_url }}">Reflections Working Group</a>{% if C.footer.contact_email %} or write to <a class="underline" href="mailto:{{ C.footer.contact_email }}">{{ C.footer.contact_email }}</a>{% endif %}.</p>
-      {% endif %}
     </div>
   </section>
 


### PR DESCRIPTION
Removes the ballot block from /geneva-reflections/ — everything from "**How the vote works:**" through **P10**: the QV explainer, the ten-item ballot list with grounding expanders, the status line, the QV-results container, and the feedback ask that referred to the removed list.

Kept: the four-step timeline (deliberation → Reflections Working Group → quadratic vote → Geneva Reflection Principles).

Also cleaned up the two sentences that pointed at the removed block (the split lead's "survives into the draft principles below" and the strange-bedfellows takeaway's link to P10). The principle definitions stay parked unrendered in `content.json` / `qv-results.json`, so restoring or reworking the section later needs no data reconstruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)