### PR TITLE
Geneva Reflections: shape-and-concision pass + four-pillar restructure

### DIFF
--- a/site-data/content.json
+++ b/site-data/content.json
@@ -13,10 +13,22 @@
     "dialogue_url": "https://www.un.org/global-dialogue-ai-governance/en",
     "official_line": "An official virtual side event of the first UN Global Dialogue on AI Governance",
     "conveners": [
-      { "name": "Parity", "url": "https://www.parity.nyc" },
-      { "name": "Sikh LGBT+ Inclusion", "url": null },
-      { "name": "RadicalxChange Foundation", "url": "https://www.radicalxchange.org" },
-      { "name": "Free Community Church", "url": "https://www.fcc.org.sg" }
+      {
+        "name": "Parity",
+        "url": "https://www.parity.nyc"
+      },
+      {
+        "name": "Sikh LGBT+ Inclusion",
+        "url": null
+      },
+      {
+        "name": "RadicalxChange Foundation",
+        "url": "https://www.radicalxchange.org"
+      },
+      {
+        "name": "Free Community Church",
+        "url": "https://www.fcc.org.sg"
+      }
     ]
   },
   "stats": {
@@ -32,54 +44,59 @@
   "consensus": {
     "kicker": "01 · The common ground",
     "title": "What the room agreed on",
-    "intro": "Start with the red lines the room drew together: it rejected trading privacy for intimate personalization — six agreed, twenty disagreed, and in the smaller bloc not one person took the yes side; it demanded limits on surveillance and on who sees what people confide; it distrusted advice from a system that isn't designed to disagree with you; and it named the flattening of distinct voices into an average. This floor belongs to the whole room, not one side. On it, six demands drew broad support — each shown with one statement in participants' own words; expand a theme for its supporting statements and each bloc's numbers. Where the room split, it split over the remedy, not over whether AI needs remaking — that split comes next.",
-    "redline_refs": [
-      { "id": 4, "note": "rejected" },
-      { "id": 67 },
-      { "id": 65 },
-      { "id": 36 },
-      { "id": 26 },
-      { "id": 42 }
-    ],
+    "intro": "Four demands drew broad support. Where the room split comes next.",
     "themes": [
       {
-        "title": "Contestability & accountability",
-        "blurb": "Communities must be able to challenge and correct how AI represents them; whoever sets an AI system's values must answer to the people affected — through regulation with teeth.",
+        "title": "Answer to the people affected",
+        "blurb": "Communities can challenge and correct how AI portrays them; whoever sets AI's values answers for it; regulation is a necessity.",
         "exemplar": 2,
-        "supporting": [10, 21]
-      },
-      {
-        "title": "Protection from dependency & manipulation",
-        "blurb": "Design AI against emotional over-dependence and manipulation — protections the whole room wanted as defaults, not options.",
-        "exemplar": 16,
-        "supporting": [7, 5, 51]
-      },
-      {
-        "title": "Human-reserved ground",
-        "blurb": "Some questions — and, above all, care itself — must stay human. AI can support, but never substitute.",
-        "exemplar": 68,
-        "supporting": [53, 13, 14]
-      },
-      {
-        "title": "Data, consent & surveillance",
-        "blurb": "Strict limits on who sees what people confide to AI, and a shared alarm about AI-enabled surveillance.",
-        "exemplar": 65,
-        "supporting": [67, 25, 6]
-      },
-      {
-        "title": "Community authorship",
-        "blurb": "Communities should be able to build and shape AI on their own values, with each member seeing their own data first.",
-        "exemplar": 17,
-        "supporting": [3, 15],
-        "cross_refs": [
-          { "id": 6, "label": "See also the consent duty participants set for community-built AI — statement [6], under Data, consent & surveillance" }
+        "supporting": [
+          10,
+          21
         ]
       },
       {
-        "title": "Value transparency & epistemic care",
-        "blurb": "Disclose whose values an AI carries, and take care with how knowledge — including faith traditions passed between generations — is transmitted.",
-        "exemplar": 47,
-        "supporting": [48, 62, 19]
+        "title": "Don't use knowing us against us",
+        "blurb": "The room rejected trading privacy for personalization outright; it wants AI designed against emotional over-dependence even when users want the closeness, and hard limits on surveillance and on who sees what people confide.",
+        "exemplar": 16,
+        "supporting": [
+          4,
+          67,
+          65,
+          7,
+          5,
+          51,
+          25,
+          6
+        ],
+        "notes": {
+          "4": "rejected; among Boundary Keepers, not one person agreed"
+        }
+      },
+      {
+        "title": "Keep some ground human",
+        "blurb": "Some questions should only ever be answered by a person; AI must never substitute for human care; and advice from a system not designed to disagree with you deserves distrust.",
+        "exemplar": 13,
+        "supporting": [
+          53,
+          68,
+          14,
+          36,
+          19,
+          62,
+          74,
+          80
+        ]
+      },
+      {
+        "title": "Don't flatten us into an average",
+        "blurb": "Distinct voices and worldviews stay visible — no averaging everyone into the same output, and disclosure of whose values a response carries.",
+        "exemplar": 26,
+        "supporting": [
+          42,
+          47,
+          48
+        ]
       }
     ]
   },
@@ -92,16 +109,30 @@
       {
         "key": "A",
         "name": "Boundary Keepers",
-        "sketch": "Wants clear limits on where AI belongs. For this bloc the remedy is boundaries: whoever builds AI, some human ground stays reserved — some questions should only ever be answered by a person, and being deeply known by a machine reads as a loss, not a comfort. They often abstained on statements about being misrepresented by AI (distance from that experience, not opposition to fixing it) — and their stance on community-built AI is abstention too, not objection: on the flagship authorship statement, seven of thirteen passed, four agreed, two disagreed. An invitation to demonstrate, rather than a door closed.",
+        "sketch": "Wants clear limits on where AI belongs. Whoever builds it, some human ground stays reserved: some questions should only ever be answered by a person, and being deeply known by a machine reads as a loss, not a comfort. On community-built AI, they abstained far more than they objected: seven of thirteen passed, four agreed, two disagreed.",
         "cards": [],
-        "references": [9, 13, 23, 30, 55]
+        "references": [
+          9,
+          13,
+          23,
+          30,
+          55
+        ]
       },
       {
         "key": "C",
         "name": "Recognition Seekers",
-        "sketch": "Knows what it feels like when AI describes their faith or culture like an outsider — and insists that fixing this is AI's job, not theirs. Their remedy is authorship: communities building and steering AI on their own terms — the one affirmative program in the data with broad support and no organized opposition. They want recognition without capture: firmly against manipulation and privacy trade-offs.",
-        "cards": [0],
-        "references": [9, 5, 15, 3]
+        "sketch": "Knows what it feels like when AI describes their faith or culture like an outsider. Their remedy is authorship: communities building and steering AI on their own terms — the one affirmative program in the data with broad support and no organized opposition.",
+        "cards": [
+          0,
+          17,
+          3,
+          15
+        ],
+        "references": [
+          9,
+          5
+        ]
       }
     ],
     "methods_note": "Per-bloc breakdowns cover the two blocs; the remaining participants are counted in totals only."
@@ -112,6 +143,7 @@
     "lead": "“It isn't AI's job to reflect every culture's values” is the room's cleanest divide: the Boundary Keepers' signature position and the Recognition Seekers' sharpest rejection. Universality versus representation is a real disagreement, not a misunderstanding.",
     "statement": 9
   },
+  "closing": "The split is over the remedy. The one affirmative program in the data — communities building and steering AI on their own terms — faces no organized opposition. And the bloc that holds back abstains rather than objects: an invitation to demonstrate, rather than a door closed.",
   "surprise": {
     "kicker": "04 · The findings a standard poll would miss",
     "title": "The surprise",
@@ -119,10 +151,14 @@
     "bedfellows": {
       "finding_label": "Finding one — agreement across the divide",
       "title": "Strange bedfellows",
-      "caption": "Boundary Keepers and Recognition Seekers stand at opposite poles on whose job it is to reflect a culture's values. But on one thing they speak with a single voice: they do not want AI to know them intimately. “I don't want to feel seen by AI” carried both blocs — six agreed in one, eleven in the other — and the statements of loss beside it lean the same way.",
-      "reading": "How to read the cards: in each one, blocs A and C — the rivals of the divide above — lean the same way. Agreement that crosses the room's main fault line is the finding.",
+      "caption": "Boundary Keepers and Recognition Seekers stand at opposite poles on whose job it is to reflect a culture's values. But on one thing they speak with a single voice: they do not want AI to know them intimately. “I don't want to feel seen by AI” carried both blocs and the statements of loss beside it lean the same way.",
+      "reading": "How to read the cards: in each one, both blocs — the rivals of the divide above — lean the same way. Agreement that crosses the room's main fault line is the finding.",
       "takeaway": "This is the room's hidden second consensus: whatever else AI becomes, the right not to be intimately known by it must be protected.",
-      "statements": [23, 30, 55],
+      "statements": [
+        23,
+        30,
+        55
+      ],
       "cross_ref_note": "The divide these two blocs are known for:"
     },
     "inner_life": {
@@ -131,7 +167,12 @@
       "caption": "Whether AI belongs in the inner and spiritual life — as a deepener of tradition, a moral interlocutor, or not at all — is not a fight between the blocs. It runs through them: members of the same bloc, who vote together on nearly everything else, part ways here.",
       "reading": "How to read the cards: the bars below are within each bloc. Where a bloc's bar shows both solid (agree) and striped (disagree) in near-equal measure, that bloc is divided against itself.",
       "takeaway": "Neither bloc can settle this question for the room, because neither has settled it for itself.",
-      "statements": [1, 12, 33, 43]
+      "statements": [
+        1,
+        12,
+        33,
+        43
+      ]
     }
   },
   "notes": {
@@ -185,16 +226,116 @@
     "principles_intro": "These are starting points, not a finished ballot: readings of the deliberation record, distilled into the kind of principles the room seemed to be asking for. The Reflections Working Group is making sense of the Pol.is results now, and these ideas are theirs to challenge, rewrite, merge, or replace — each one cites the statements it is drawn from, so the drafting can be checked against the votes. Two sit on live tensions the room did not resolve; if they survive revision, the quadratic vote will weigh them.",
     "feedback_ask": "If you took part in the event: do these ideas capture what you said — and what did we miss? Tell us which to keep, rework, or drop.",
     "principles": [
-      { "id": "P1", "title": "Contestability", "text": "Guarantee communities a binding, resourced channel to challenge how an AI system represents their tradition and to get errors fixed.", "grounding": [2, 10, 45], "tension": false },
-      { "id": "P2", "title": "Answerability of value-setters", "text": "Make whoever sets an AI system's values legally accountable, through enforceable regulation, to the people affected.", "grounding": [10, 21, 20], "tension": false },
-      { "id": "P3", "title": "Anti-dependency design", "text": "Require AI to be designed against emotional over-dependence, with disengagement behavior measured and publicly reported.", "grounding": [16, 7, 51], "tension": false },
-      { "id": "P4", "title": "Manipulation firewall", "text": "Protection from manipulation as a non-overridable default.", "grounding": [5, 4, 25], "tension": false },
-      { "id": "P5", "title": "Human-reserved care", "text": "Care for one another, and defined classes of questions, stay human; AI supports but never substitutes.", "grounding": [53, 13, 68], "tension": false },
-      { "id": "P6", "title": "Deliberation, not verdicts", "text": "In value-laden domains AI asks for context and helps people think rather than delivering answers.", "grounding": [14, 41, 12], "tension": true },
-      { "id": "P7", "title": "Community authorship", "text": "Communities can build or shape AI on their own values, each member seeing their own data first.", "grounding": [3, 17, 6], "tension": false },
-      { "id": "P8", "title": "Worldview transparency", "text": "Disclose when a response carries a particular worldview and whose values defaults average over.", "grounding": [47, 48, 8], "tension": false },
-      { "id": "P9", "title": "Data & surveillance limits", "text": "Strict, auditable limits on who accesses what people put into AI; AI-enabled surveillance treated as a first-order harm.", "grounding": [65, 67, 25], "tension": false },
-      { "id": "P10", "title": "The right not to be seen", "text": "An effective, penalty-free right to keep AI out of one's inner, moral, and spiritual life, while protecting those who choose to invite it in.", "grounding": [23, 33, 16], "tension": true }
+      {
+        "id": "P1",
+        "title": "Contestability",
+        "text": "Guarantee communities a binding, resourced channel to challenge how an AI system represents their tradition and to get errors fixed.",
+        "grounding": [
+          2,
+          10,
+          45
+        ],
+        "tension": false
+      },
+      {
+        "id": "P2",
+        "title": "Answerability of value-setters",
+        "text": "Make whoever sets an AI system's values legally accountable, through enforceable regulation, to the people affected.",
+        "grounding": [
+          10,
+          21,
+          20
+        ],
+        "tension": false
+      },
+      {
+        "id": "P3",
+        "title": "Anti-dependency design",
+        "text": "Require AI to be designed against emotional over-dependence, with disengagement behavior measured and publicly reported.",
+        "grounding": [
+          16,
+          7,
+          51
+        ],
+        "tension": false
+      },
+      {
+        "id": "P4",
+        "title": "Manipulation firewall",
+        "text": "Protection from manipulation as a non-overridable default.",
+        "grounding": [
+          5,
+          4,
+          25
+        ],
+        "tension": false
+      },
+      {
+        "id": "P5",
+        "title": "Human-reserved care",
+        "text": "Care for one another, and defined classes of questions, stay human; AI supports but never substitutes.",
+        "grounding": [
+          53,
+          13,
+          68
+        ],
+        "tension": false
+      },
+      {
+        "id": "P6",
+        "title": "Deliberation, not verdicts",
+        "text": "In value-laden domains AI asks for context and helps people think rather than delivering answers.",
+        "grounding": [
+          14,
+          41,
+          12
+        ],
+        "tension": true
+      },
+      {
+        "id": "P7",
+        "title": "Community authorship",
+        "text": "Communities can build or shape AI on their own values, each member seeing their own data first.",
+        "grounding": [
+          3,
+          17,
+          6
+        ],
+        "tension": false
+      },
+      {
+        "id": "P8",
+        "title": "Worldview transparency",
+        "text": "Disclose when a response carries a particular worldview and whose values defaults average over.",
+        "grounding": [
+          47,
+          48,
+          8
+        ],
+        "tension": false
+      },
+      {
+        "id": "P9",
+        "title": "Data & surveillance limits",
+        "text": "Strict, auditable limits on who accesses what people put into AI; AI-enabled surveillance treated as a first-order harm.",
+        "grounding": [
+          65,
+          67,
+          25
+        ],
+        "tension": false
+      },
+      {
+        "id": "P10",
+        "title": "The right not to be seen",
+        "text": "An effective, penalty-free right to keep AI out of one's inner, moral, and spiritual life, while protecting those who choose to invite it in.",
+        "grounding": [
+          23,
+          33,
+          16
+        ],
+        "tension": true
+      }
     ]
   },
   "panelist_quotes": [

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -175,6 +175,10 @@
   align-items: center;
   font-size: var(--step--3);
 }
+/* rows labeled by bloc first-word instead of a letter */
+.geneva .gr-mini-name {
+  grid-template-columns: 5.6rem minmax(0, 1fr) auto;
+}
 .geneva .gr-text-A { color: var(--gr-group-a); }
 .geneva .gr-text-B { color: var(--gr-group-b); }
 .geneva .gr-text-C { color: var(--gr-group-c); }

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -97,13 +97,16 @@ description: "What would AI governance need to do so that everyone felt seen by 
 </div>
 {% endmacro %}
 
+{% set blocNames = {"A": "Boundary Keepers", "C": "Recognition Seekers"} %}
+{% set blocShort = {"A": "Boundary", "C": "Recognition"} %}
+
 {% macro groupRows(s) %}
 <div class="flex flex-col gap-1">
   {% for g in ["A", "C"] %}
   {% set t = s.groups[g] %}
-  <div class="gr-mini">
-    <span class="font-bold gr-text-{{ g }}" aria-hidden="true">{{ g }}</span>
-    {{ stackBar(t, "Bloc " + g) }}
+  <div class="gr-mini gr-mini-name">
+    <span class="font-bold gr-text-{{ g }}" aria-hidden="true">{{ blocShort[g] }}</span>
+    {{ stackBar(t, blocNames[g]) }}
     <span class="gr-counts">{% if t.votes > 0 %}{{ (t.agree_rate * 100) | round }}% agree ({{ t.agrees }}/{{ t.votes }}){% else %}–{% endif %}{{ thinGlyph(t) }}</span>
   </div>
   {% endfor %}
@@ -126,8 +129,8 @@ description: "What would AI governance need to do so that everyone felt seen by 
 </div>
 {% endmacro %}
 
-{# Tier-2 card: adds the per-group breakdown. #}
-{% macro cardFull(sid) %}
+{# Tier-2 card: adds the per-group breakdown; note flags e.g. rejections. #}
+{% macro cardFull(sid, note) %}
 {% set s = S["" ~ sid] %}
 <div class="gr-card flex flex-col gap-3" id="s{{ s.id }}">
   <p class="gr-stmt-text flex-grow">“{{ s.text }}”</p>
@@ -136,7 +139,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
     {{ sourceBadge(s) }}
   </div>
   {{ stackBar(s.total, "All participants") }}
-  <p class="gr-counts"><strong class="text-black">{{ figureFor(s) }}</strong></p>
+  <p class="gr-counts"><strong class="text-black">{{ figureFor(s) }}</strong>{% if note %} — {{ note }}{% endif %}</p>
   {{ groupRows(s) }}
 </div>
 {% endmacro %}
@@ -212,15 +215,12 @@ description: "What would AI governance need to do so that everyone felt seen by 
       <p class="gr-kicker mb-2">{{ C.consensus.kicker }}</p>
       <h2 class="mb-4">{{ C.consensus.title }}</h2>
       <p class="gr-prose mb-4">{{ C.consensus.intro }}</p>
-      {% if C.consensus.redline_refs %}
-      <p class="gr-counts gr-prose mb-4">The red lines: {% for ref in C.consensus.redline_refs %}{{ refLine(ref.id) }}{% if ref.note %} — {{ ref.note }}{% endif %}{% if not loop.last %} · {% endif %}{% endfor %}</p>
-      {% endif %}
       <div class="gr-legend mb-8">
         <span><span class="gr-swatch" style="background:#1a1a1a"></span>agree</span>
         <span><span class="gr-swatch" style="background:#d9d9d9"></span>pass</span>
         <span><span class="gr-swatch" style="background:repeating-linear-gradient(-45deg,#fff,#fff 3px,#6c6c6c 3px,#6c6c6c 4px)"></span>disagree</span>
       </div>
-      <div class="grid gap-x-8 gap-y-8 md:grid-cols-2 lg:grid-cols-3">
+      <div class="grid gap-x-8 gap-y-8 md:grid-cols-2">
         {% for theme in C.consensus.themes %}
         <div class="gr-theme">
           <h3 class="mb-2">{{ theme.title }}</h3>
@@ -234,7 +234,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
                 {{ groupRows(S["" ~ theme.exemplar]) }}
               </div>
               {% for sid in theme.supporting %}
-              {{ cardFull(sid) }}
+              {{ cardFull(sid, theme.notes["" ~ sid] if theme.notes else null) }}
               {% endfor %}
               {% if theme.cross_refs %}
               <p class="gr-counts">{% for ref in theme.cross_refs %}<a class="underline" href="#s{{ ref.id }}">{{ ref.label }}</a>{% if not loop.last %} · {% endif %}{% endfor %}</p>
@@ -256,7 +256,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
       <div class="gr-groups">
         {% for grp in C.groups.list %}
         <article class="gr-group-col gr-border-{{ grp.key }}">
-          <h3 class="mb-1"><span class="gr-text-{{ grp.key }}">{{ grp.key }}</span> — {{ grp.name }}</h3>
+          <h3 class="mb-1"><span class="gr-text-{{ grp.key }}">{{ grp.name }}</span></h3>
           <p class="gr-counts mb-3">{{ P.group_sizes[grp.key] }} participants</p>
           <p class="text-size--1 mb-3">{{ grp.sketch }}</p>
           <details>
@@ -324,6 +324,15 @@ description: "What would AI governance need to do so that everyone felt seen by 
       <p class="gr-prose font-bold text-size--1">{{ C.surprise.inner_life.takeaway }}</p>
     </div>
   </section>
+
+  {# ---------- closing ---------- #}
+  {% if C.closing %}
+  <section aria-label="Closing" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9">
+      <p class="gr-prose font-bold text-size-1">{{ C.closing }}</p>
+    </div>
+  </section>
+  {% endif %}
 
   {# ---------- 5. what happens next ---------- #}
   <section id="next" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">


### PR DESCRIPTION
Two approved passes, one coherent change. **Net word delta vs main: −180 total, −327 in the default (expanders-closed) view.**

## Shape & concision
- **Closing passage** after section 04 gives the story its ending: "The split is over the remedy. The one affirmative program in the data — communities building and steering AI on their own terms — faces no organized opposition. And the bloc that holds back abstains rather than objects: an invitation to demonstrate, rather than a door closed." The abstention/invitation beat leaves the Boundary Keepers sketch accordingly.
- **Bloc sketches** rewritten need-to-know (~45/~40 words, approved texts verbatim); the remedy line de-duplicated (lives only in 02's intro); 01 loses its UI-mechanics sentence.
- **Letter labels gone everywhere**: color-coded bloc names in headers; "Boundary"/"Recognition" in per-card breakdown rows (full names in tooltips/aria-labels); named data-page columns; bedfellows caption drops "— six agreed in one, eleven in the other —".

## Section 01 → four pillars, one scheme
Default view: intro ("Four demands drew broad support. Where the room split comes next.") + four title/gloss/flagship-card blocks; everything else behind the existing expanders.

Full mapping (every statement from the old six blocks + red-lines strip):
| Pillar | Flagship | Evidence |
|---|---|---|
| Answer to the people affected | [2] | [10] [21] |
| Don't use knowing us against us | [16] | [4] (noted "rejected; among Boundary Keepers, not one person agreed") [67] [65] [7] [5] [51] [25] [6] |
| Keep some ground human | [13] | [53] [68] [14] [36] [19] [62] [74] [80] |
| Don't flatten us into an average | [26] | [42] [47] [48] |

Community-authorship statements ([17] [3] [15]) move to Recognition Seekers' supporting evidence in 02. Only conscious drop: the [6] see-also cross-reference note. [74]/[80] added as new pillar-3 evidence ("if present" — they are). Pillar-2's gloss omits the duplicate 17%-parenthetical (the fact renders on the [4] card); the closing opens "The split is over the remedy" since "floor" is barred and no longer established.

## Verified on the built output
Zero broken same-page or data-page anchors · zero duplicate cards (render-once intact) · no bare A/C labels in any row, header, or caption · no tallies in 01 prose · "floor" appears nowhere · pre-existing timeline step untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)