### PR TITLE
Geneva Reflections: TL;DR block up top, closing passage removed

### DIFF
--- a/site-data/content.json
+++ b/site-data/content.json
@@ -143,7 +143,6 @@
     "lead": "“It isn't AI's job to reflect every culture's values” is the room's cleanest divide: the Boundary Keepers' signature position and the Recognition Seekers' sharpest rejection. Universality versus representation is a real disagreement, not a misunderstanding.",
     "statement": 9
   },
-  "closing": "The split is over the remedy. The one affirmative program in the data — communities building and steering AI on their own terms — faces no organized opposition. And the bloc that holds back abstains rather than objects: an invitation to demonstrate, rather than a door closed.",
   "surprise": {
     "kicker": "04 · The findings a standard poll would miss",
     "title": "The surprise",
@@ -362,5 +361,9 @@
     "rwg_signup_label": "Join the Reflections Working Group",
     "contact_email": "info@radicalxchange.org",
     "event_page_url": "/updates/announcements/2026-07-can-ai-see-me/"
+  },
+  "tldr": {
+    "kicker": "00 · The TL;DR",
+    "text": "The room drew its red lines together — against intimate personalization, surveillance, and AI that flatters rather than challenges — and then split not over whether AI needs remaking but over the remedy. The larger bloc's answer is authorship: communities building and steering AI on their own terms, the one affirmative program in the data with broad support and no organized opposition. The smaller bloc's answer is boundaries: whoever builds it, some human ground stays reserved. And the boundary-keepers don't reject communal AI — they just passed on it, which suggests an invitation to demonstrate rather than a door closed."
   }
 }

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -209,6 +209,16 @@ description: "What would AI governance need to do so that everyone felt seen by 
     </div>
   </section>
 
+  {# ---------- 00. the tl;dr ---------- #}
+  {% if C.tldr %}
+  <section aria-label="TL;DR" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-10">
+      <p class="gr-kicker mb-2">{{ C.tldr.kicker }}</p>
+      <p class="font-bold text-size-1">{{ C.tldr.text }}</p>
+    </div>
+  </section>
+  {% endif %}
+
   {# ---------- 1. what the room agreed on ---------- #}
   <section id="agreed" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2">
@@ -324,15 +334,6 @@ description: "What would AI governance need to do so that everyone felt seen by 
       <p class="gr-prose font-bold text-size--1">{{ C.surprise.inner_life.takeaway }}</p>
     </div>
   </section>
-
-  {# ---------- closing ---------- #}
-  {% if C.closing %}
-  <section aria-label="Closing" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9">
-      <p class="gr-prose font-bold text-size-1">{{ C.closing }}</p>
-    </div>
-  </section>
-  {% endif %}
 
   {# ---------- 5. what happens next ---------- #}
   <section id="next" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">


### PR DESCRIPTION
Adds the "00 · THE TL;DR" block between the question and section 01 — house kicker + standout bold paragraph, no card machinery, text verbatim as supplied — and cuts the closing passage after section 04, whose beat the TL;DR now carries.

## Gate report
**Before/after:**
- *New (00):* kicker "00 · THE TL;DR" + the supplied paragraph ("The room drew its red lines together — … an invitation to demonstrate rather than a door closed.")
- *Removed (after 04):* "The split is over the remedy. The one affirmative program in the data — … an invitation to demonstrate, rather than a door closed."

**Collision check — two flags (left as-is per instruction, not silently reworded):**
1. TL;DR sentence 2 vs the **Recognition Seekers sketch**: "authorship: communities building and steering AI on their own terms — the one affirmative program in the data with broad support and no organized opposition" — ~20 words shared near-verbatim.
2. TL;DR sentence 3 vs the **Boundary Keepers sketch**: "whoever builds it, some human ground stays reserved" — verbatim 8-word clause.

The remedy line ("not over whether AI needs remaking…") and "red lines" each appear once in the body — within tolerance as specified. "Invitation to demonstrate" now appears only in the TL;DR (the closing that carried it is gone).

**Net word delta vs main:** +57 (TL;DR ≈ +102, closing cut ≈ −45).
**Link check:** zero broken same-page or data-page anchors; zero duplicate cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)