### PR TITLE
Geneva Reflections: vote-color palette + TL;DR/sketch copy

### DIFF
--- a/site-data/content.json
+++ b/site-data/content.json
@@ -109,7 +109,7 @@
       {
         "key": "A",
         "name": "Boundary Keepers",
-        "sketch": "Wants clear limits on where AI belongs. Whoever builds it, some human ground stays reserved: some questions should only ever be answered by a person, and being deeply known by a machine reads as a loss, not a comfort. On community-built AI, they abstained far more than they objected: seven of thirteen passed, four agreed, two disagreed.",
+        "sketch": "Wants clear limits on where AI belongs, and thinks some questions should only ever be answered by a person, and being deeply known by a machine reads as a loss, not a comfort. On community-built AI, they agreed or passed far more than they objected.",
         "cards": [],
         "references": [
           9,
@@ -364,6 +364,6 @@
   },
   "tldr": {
     "kicker": "00 · The TL;DR",
-    "text": "The room drew its red lines together — against intimate personalization, surveillance, and AI that flatters rather than challenges — and then split not over whether AI needs remaking but over the remedy. The larger bloc's answer is authorship: communities building and steering AI on their own terms, the one affirmative program in the data with broad support and no organized opposition. The smaller bloc's answer is boundaries: whoever builds it, some human ground stays reserved. And the boundary-keepers don't reject communal AI — they just passed on it, which suggests an invitation to demonstrate rather than a door closed."
+    "text": "The room drew its red lines together — against intimate personalization, surveillance, and AI that flatters rather than challenges — and then split not over whether AI needs remaking but over the remedy. The larger bloc's answer is authorship: communities building and steering AI on their own terms. The smaller bloc's answer is boundaries: whoever builds it, some human ground stays reserved. And the boundary-keepers appear open to communal AI — they mainly passed or agreed with those statements, an invitation to demonstrate rather than a door closed. That makes authorship the one affirmative program in the data with broad support and no organized opposition."
   }
 }

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -8,9 +8,14 @@
   --gr-group-a: #0072b2; /* Okabe–Ito blue */
   --gr-group-b: #d55e00; /* Okabe–Ito vermillion */
   --gr-group-c: #009e73; /* Okabe–Ito bluish green */
-  --gr-agree: #1a1a1a;
-  --gr-pass: #d9d9d9;
-  --gr-disagree-border: #6c6c6c;
+  /* vote palette (one system; bloc blue/green never shares an element
+     with it): agree = deep madder, inky enough to hold its own against
+     the black display type; pass = warm neutral; disagree keeps the
+     diagonal hatch in a cool ink-gray so grayscale/print/colorblind
+     readers get the same encoding. */
+  --gr-agree: #8c2b1e;
+  --gr-pass: #d9d2c9;
+  --gr-disagree-border: #47525c;
   --gr-rule: #e5e5e5;
 }
 
@@ -215,6 +220,13 @@
 }
 .geneva .gr-thin {
   color: #6c6c6c;
+}
+/* companion touch (one, after the self-critique pass): headline tally
+   bolds pick up the agree accent, tying the number to the agree fill it
+   summarizes. The vote palette stays off statement-provenance badges —
+   those are metadata, not votes (two systems, no blending). */
+.geneva .gr-counts strong {
+  color: var(--gr-agree);
 }
 /* thin-data table cells: greyed, per the ◔ legend (background carries the
    de-emphasis; text stays WCAG AA against it) */

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -226,9 +226,9 @@ description: "What would AI governance need to do so that everyone felt seen by 
       <h2 class="mb-4">{{ C.consensus.title }}</h2>
       <p class="gr-prose mb-4">{{ C.consensus.intro }}</p>
       <div class="gr-legend mb-8">
-        <span><span class="gr-swatch" style="background:#1a1a1a"></span>agree</span>
-        <span><span class="gr-swatch" style="background:#d9d9d9"></span>pass</span>
-        <span><span class="gr-swatch" style="background:repeating-linear-gradient(-45deg,#fff,#fff 3px,#6c6c6c 3px,#6c6c6c 4px)"></span>disagree</span>
+        <span><span class="gr-swatch" style="background:var(--gr-agree)"></span>agree</span>
+        <span><span class="gr-swatch" style="background:var(--gr-pass)"></span>pass</span>
+        <span><span class="gr-swatch" style="background:repeating-linear-gradient(-45deg,#fff,#fff 3px,var(--gr-disagree-border) 3px,var(--gr-disagree-border) 4px)"></span>disagree</span>
       </div>
       <div class="grid gap-x-8 gap-y-8 md:grid-cols-2">
         {% for theme in C.consensus.themes %}


### PR DESCRIPTION
An aesthetics pass introducing a vote-color scheme for the agree/pass/disagree bars site-wide on this page, plus the approved TL;DR and Boundary-Keepers copy changes. Approved at the style-tile gate.

## Vote palette (design tokens)
| Vote | Token | Contrast |
|---|---|---|
| **Agree** | `#8C2B1E` deep madder | 8.47:1 on card white (AAA as text) · 7.69:1 on page bg · 2.05:1 vs black display type — reads as its own warm, still inky |
| **Pass** | `#D9D2C9` warm neutral | position-encoded, border-bounded (as before) |
| **Disagree** | diagonal hatch in `#47525C` cool ink | 7.99:1 — pattern carries the encoding in grayscale/print/colorblind |

Not terracotta-clay (`#D97757`), not red — a browned madder. Grayscale render at the gate confirmed all three segments stay distinguishable without color; color is never the sole encoding.

**Two systems, no blending:** bloc blue/green appears only on bloc names, column rules, and row labels; the vote palette only on bar fills, legend swatches, and tallies. No element carries both.

**Companion touches — shipped one, not two.** Headline tally bolds pick up the agree accent (the bolded number *is* the agree figure). The self-critique pass **removed** the second candidate — the WRITTEN LIVE badge outline — because statement-provenance badges are metadata, not votes; coloring them with the vote-agree accent would blend the two systems. The Chanel rule lands on the cleaner single touch.

CSS-only for the palette: no copy or layout change from it, reduced-motion and print unaffected (the hatch renders disagree in print).

## Copy changes
- **TL;DR** final sentences → authorship/boundaries split; "the boundary-keepers appear open to communal AI — they mainly passed or agreed with those statements, an invitation to demonstrate rather than a door closed"; authorship = "the one affirmative program in the data with broad support and no organized opposition."
- **Boundary Keepers sketch** tightened to echo the new framing ("they agreed or passed far more than they objected"). Side effects, both improvements flagged in earlier gates: the page's last `abstain` phrasing is gone (0 instances), and "some human ground stays reserved" now appears only in the TL;DR (the earlier duplicate is resolved).

Consistency sweep: no post-#250 closing line exists to update (it was cut in that PR); `abstain` grep returns zero; no remaining phrasing contradicts "passed or agreed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)