### PR TITLE
Geneva Reflections: QV results, intuitive vote colors, forward story

### DIFF
--- a/documentation/geneva-reflections-blog-draft.md
+++ b/documentation/geneva-reflections-blog-draft.md
@@ -1,0 +1,84 @@
+# DRAFT — not published. Blog post to accompany /geneva-reflections/
+
+> Status: draft for review. Lives in documentation/ so it does not build.
+> To publish: review, set a date/slug, and move into
+> src/site/updates/blog/ (or announcements/) following the conventions in
+> the site README. Suggested slug: geneva-reflection-principles.
+
+---
+
+Title options:
+1. **The room answered a question we didn't ask** (matches the page's hook)
+2. Ten principles from a room AI couldn't see
+3. What a multi-faith room asked of AI governance — and how it voted
+
+---
+
+On 6 July 2026, at an official virtual side event of the first [UN Global
+Dialogue on AI Governance](https://www.un.org/global-dialogue-ai-governance/en),
+we asked a room of faith leaders, peacebuilders, and technologists from
+four continents a question: **what would AI governance need to do so that
+everyone here felt seen by AI?**
+
+Ten days later, ten participant-authored principles — reviewed by the
+room, prioritized by the room, with the full voting record attached — were
+delivered to the Dialogue's Joint Secretariat. This post is about what
+happened in between, and why we think the method mattered as much as the
+outcome. The full results live at
+[radicalxchange.org/geneva-reflections](https://www.radicalxchange.org/geneva-reflections/).
+
+## What the room said
+
+Thirty-nine participants deliberated on 84 statements in a live Pol.is
+conversation — three-quarters of the statements written by participants
+themselves, in their own words, during and after the session. The room
+drew its red lines together: it rejected trading privacy for intimate
+personalization, demanded hard limits on surveillance and on who sees what
+people confide to AI, distrusted advice from systems not designed to
+disagree, and named the flattening of distinct voices into an average as a
+harm in its own right.
+
+Where the room split, it split not over whether AI needs remaking but over
+the remedy. The larger bloc's answer is authorship: communities building
+and steering AI on their own terms. The smaller bloc's answer is
+boundaries: whoever builds it, some human ground stays reserved. And the
+boundary-holders didn't reject communal AI — they mainly passed or agreed,
+an openness that reads as an invitation to demonstrate rather than a door
+closed.
+
+## What the vote settled
+
+A participant working group distilled the record into ten principles, and
+seventeen participants then weighed them in a quadratic vote — each with
+100 voice credits, where one vote costs 1 credit, two cost 4, three cost
+9, so spending reveals how much people care, not just what they prefer.
+
+Under that budget, the room's floors held. *Privacy, not surveillance* and
+*Never manipulate* tied for first with 62 votes each — and not a single
+voter spent against either. *Community-built AI* drew credits from every
+voter: the one affirmative program in the data, now confirmed under
+scarcity. And the room chose not to force its own open question — the
+right to choose AI's place in faith drew the least spending, left open on
+purpose.
+
+## Why the method mattered
+
+A poll would have produced a majority and a minority. Bridging
+deliberation, plus a working group, plus a quadratic vote produced
+something more useful: a map of where a genuinely plural room converges,
+where it holds principled disagreement, and which of its demands it would
+actually spend limited resources to advance. That map — common knowledge a
+community holds about itself — is what we delivered to the UN, and it is
+what makes the next step possible.
+
+## What's next
+
+The Geneva Reflection Principles are with the Joint Secretariat. We are
+now shaping the next phase of this work: supporting communities of belief
+to author and govern AI of their own — so that the people AI describes
+from the outside become the people building it from the inside.
+
+*"Can AI See Me?" was convened by Parity with Sikh LGBT+ Inclusion, Free
+Community Church, and RadicalxChange Foundation. Watch the
+[session recording](https://youtu.be/Rj419GhtAG4) or explore
+[every statement and vote](https://www.radicalxchange.org/geneva-reflections/data/).*

--- a/site-data/content.json
+++ b/site-data/content.json
@@ -196,27 +196,27 @@
   },
   "pipeline": {
     "kicker": "05 · From results to principles",
-    "title": "What happens next",
+    "title": "What happened next",
     "steps": [
       {
         "label": "Pol.is deliberation",
-        "detail": "38 participants, live during the side event and open for 24 hours after — the results on this page.",
+        "detail": "39 participants, live during the side event and open for 24 hours after — the results on this page.",
         "status": "done"
       },
       {
         "label": "Reflections Working Group",
-        "detail": "Where we are now: participants are making sense of these results together and distilling them into ballot items.",
-        "status": "current"
+        "detail": "Participants distilled the record into ten Geneva Reflection Principles and set the ballot.",
+        "status": "done"
       },
       {
-        "label": "24-hour Quadratic Vote",
-        "detail": "Every participant weighs the ballot with a shared budget of voice credits.",
-        "status": "upcoming"
+        "label": "Quadratic vote",
+        "detail": "17 participants weighed the ten principles, each with a budget of 100 voice credits.",
+        "status": "done"
       },
       {
-        "label": "Geneva Reflection Principles",
-        "detail": "The participant-authored principles, with their full voting record, submitted to the UN Global Dialogue's Joint Secretariat.",
-        "status": "upcoming"
+        "label": "UN Joint Secretariat",
+        "detail": "The principles, with their full voting record, were delivered to the Global Dialogue's Joint Secretariat ten days after the event.",
+        "status": "done"
       }
     ],
     "qv_explainer": "Quadratic voting measures how much people care, not just what they prefer. Each voter gets the same budget of credits; one vote for a principle costs 1 credit, two votes cost 4, three cost 9. Spreading credits is cheap, piling them on one priority is expensive — so the results reveal intensity honestly.",
@@ -335,7 +335,13 @@
         ],
         "tension": true
       }
-    ]
+    ],
+    "qv_block": {
+      "title": "What the vote prioritized",
+      "explainer": "Each of the 17 voters had 100 credits; one vote costs 1 credit, two cost 4, three cost 9 — so spending reveals how much people care, not just what they prefer. The ballot allowed spending against an item.",
+      "insights": "Three readings stand out. The room's red lines held under scarcity: forced to budget, Privacy, not surveillance and Never manipulate tied for first, and not one voter spent against either. The affirmative program held too: Community-built AI drew credits from every single voter — broad support and no organized opposition, confirmed under a budget. And the room spent on shared floors rather than on settling its inner divide: the right to choose AI's place in faith drew the least spending, with five voters leaving it untouched — the question the deliberation left open stayed open, on purpose.",
+      "forward": "Ten days after the event, the ten Geneva Reflection Principles — with this voting record — were delivered to the UN Joint Secretariat of the Global Dialogue on AI Governance. The conveners are now shaping the next phase: supporting communities of belief to author and govern AI of their own."
+    }
   },
   "panelist_quotes": [
     {
@@ -364,6 +370,6 @@
   },
   "tldr": {
     "kicker": "00 · The TL;DR",
-    "text": "The room drew its red lines together — against intimate personalization, surveillance, and AI that flatters rather than challenges — and then split not over whether AI needs remaking but over the remedy. The larger bloc's answer is authorship: communities building and steering AI on their own terms. The smaller bloc's answer is boundaries: whoever builds it, some human ground stays reserved. And the boundary-keepers appear open to communal AI — they mainly passed or agreed with those statements, an invitation to demonstrate rather than a door closed. That makes authorship the one affirmative program in the data with broad support and no organized opposition."
+    "text": "The room drew its red lines together — against intimate personalization, surveillance, and AI that flatters rather than challenges — and then split not over whether AI needs remaking but over the remedy. The larger bloc's answer is authorship: communities building and steering AI on their own terms. The smaller bloc's answer is boundaries: whoever builds it, some human ground stays reserved. And the boundary-keepers appear open to communal AI — they mainly passed or agreed with those statements, an invitation to demonstrate rather than a door closed. That makes authorship the one affirmative program in the data with broad support and no organized opposition. In the closing quadratic vote, protection from surveillance and manipulation tied for first — with not one vote against — and every voter spent credits for community-built AI. The ten principles are now with the UN Joint Secretariat."
   }
 }

--- a/site-data/qv-results.json
+++ b/site-data/qv-results.json
@@ -1,18 +1,69 @@
 {
-  "status": "pending",
-  "voted_at": null,
-  "voters": null,
-  "credits_per_voter": null,
-  "principles": [
-    { "id": "P1", "votes": null, "credits": null },
-    { "id": "P2", "votes": null, "credits": null },
-    { "id": "P3", "votes": null, "credits": null },
-    { "id": "P4", "votes": null, "credits": null },
-    { "id": "P5", "votes": null, "credits": null },
-    { "id": "P6", "votes": null, "credits": null },
-    { "id": "P7", "votes": null, "credits": null },
-    { "id": "P8", "votes": null, "credits": null },
-    { "id": "P9", "votes": null, "credits": null },
-    { "id": "P10", "votes": null, "credits": null }
+  "status": "final",
+  "voted_at": "2026-07-14",
+  "voters": 17,
+  "credits_per_voter": 100,
+  "note": "Aggregates only, by design. One vote costs 1 credit, two cost 4, three cost 9; the ballot allowed spending against an item.",
+  "items": [
+    {
+      "title": "Challenge and correct",
+      "votes": 43,
+      "against": 0,
+      "unanimous": false
+    },
+    {
+      "title": "Answerable values",
+      "votes": 45,
+      "against": 0,
+      "unanimous": false
+    },
+    {
+      "title": "No engineered dependence",
+      "votes": 41,
+      "against": 1,
+      "unanimous": false
+    },
+    {
+      "title": "Privacy, not surveillance",
+      "votes": 62,
+      "against": 0,
+      "unanimous": true
+    },
+    {
+      "title": "Care that leads to people",
+      "votes": 46,
+      "against": 1,
+      "unanimous": false
+    },
+    {
+      "title": "Teach wise use",
+      "votes": 44,
+      "against": 1,
+      "unanimous": false
+    },
+    {
+      "title": "The right to choose AI’s place in faith",
+      "votes": 15,
+      "against": 1,
+      "unanimous": false
+    },
+    {
+      "title": "Help us think, not answer for us",
+      "votes": 50,
+      "against": 0,
+      "unanimous": false
+    },
+    {
+      "title": "Never manipulate",
+      "votes": 62,
+      "against": 0,
+      "unanimous": true
+    },
+    {
+      "title": "Community-built AI",
+      "votes": 44,
+      "against": 0,
+      "unanimous": true
+    }
   ]
 }

--- a/src/site/_data/geneva.js
+++ b/src/site/_data/geneva.js
@@ -53,19 +53,12 @@ module.exports = () => {
   content.surprise.inner_life.statements.forEach(claim);
   content.carded = carded;
 
-  qv.byId = Object.fromEntries(qv.principles.map((p) => [p.id, p]));
-  qv.maxCredits = Math.max(
-    1,
-    ...qv.principles.map((p) => (p.credits == null ? 0 : p.credits))
-  );
-  // Results view renders principles sorted by credits, descending.
-  qv.sorted =
-    qv.status === "final"
-      ? [...qv.principles].sort((a, b) => (b.credits || 0) - (a.credits || 0))
-      : qv.principles;
-  content.pipeline.principlesById = Object.fromEntries(
-    content.pipeline.principles.map((p) => [p.id, p])
-  );
+  // Final quadratic-vote results: aggregate item totals only (never voter-
+  // level data). Sorted by votes, descending, for the results bars.
+  if (qv.items) {
+    qv.sorted = [...qv.items].sort((a, b) => b.votes - a.votes);
+    qv.maxVotes = Math.max(1, ...qv.items.map((i) => i.votes));
+  }
 
   return { results, content, qv };
 };

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -7,15 +7,15 @@
 .geneva {
   --gr-group-a: #0072b2; /* Okabe–Ito blue */
   --gr-group-b: #d55e00; /* Okabe–Ito vermillion */
-  --gr-group-c: #009e73; /* Okabe–Ito bluish green */
-  /* vote palette (one system; bloc blue/green never shares an element
-     with it): agree = deep madder, inky enough to hold its own against
-     the black display type; pass = warm neutral; disagree keeps the
-     diagonal hatch in a cool ink-gray so grayscale/print/colorblind
-     readers get the same encoding. */
-  --gr-agree: #8c2b1e;
+  --gr-group-c: #8a5a0e; /* deep ochre — green now belongs to the vote palette */
+  /* vote palette (one system; bloc colors never share an element with
+     it): agree = deep green (7.13:1 on white, text-grade), pass = warm
+     neutral, disagree = diagonal hatch in deep red (7.52:1) so the
+     pattern still carries the encoding in grayscale, print, and for
+     colorblind readers — color is never the sole channel. */
+  --gr-agree: #166534;
   --gr-pass: #d9d2c9;
-  --gr-disagree-border: #47525c;
+  --gr-disagree-border: #a61b1b;
   --gr-rule: #e5e5e5;
 }
 
@@ -406,16 +406,25 @@
 }
 .geneva .gr-qv-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(9rem, 16rem) minmax(0, 1fr) auto;
   gap: 0.6rem;
   align-items: center;
   font-size: var(--step--2);
   margin: 0.3rem 0;
 }
+@media (max-width: 639px) {
+  .geneva .gr-qv-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+  .geneva .gr-qv-row > span[role="img"] {
+    grid-column: 1 / -1;
+    order: 3;
+  }
+}
 .geneva .gr-qv-fill {
   display: block;
   height: 0.9rem;
-  background: #1a1a1a;
+  background: var(--gr-agree);
 }
 
 /* compact consensus themes: the section should scan, not sprawl */

--- a/src/site/_includes/css/geneva-story.css
+++ b/src/site/_includes/css/geneva-story.css
@@ -2,11 +2,6 @@
    Inherits the .geneva component styles (cards, bars, kickers); everything
    here is scoped .st- and additive. */
 
-/* inline bloc-C text needs a darker green than the dot hue for WCAG AA */
-.geneva.st .gr-text-C {
-  color: #007858;
-}
-
 /* review banner */
 .geneva .st-banner {
   display: flex;

--- a/src/site/geneva-reflections/README.md
+++ b/src/site/geneva-reflections/README.md
@@ -75,22 +75,18 @@ minimum agree rate across blocs A/C (≥4 votes per bloc); divisiveness =
 spread of net agreement between them; per-bloc tallies on fewer than 5
 votes get the ◔ "thin data" glyph.
 
-## Flipping the quadratic-vote section
+## Quadratic-vote results (final)
 
-Edit `site-data/qv-results.json`:
+`site-data/qv-results.json` holds the final QV outcome as **aggregate item
+totals only** — voter-level data (the source sheet has names) must never
+enter the repo or the page. Shape: `{status: "final", voters, 
+credits_per_voter, items: [{title, votes, against, unanimous}]}`. Section
+05 renders the items as bars sorted by votes, with "every voter in favor"
+annotations where `unanimous` is true, plus the insights and
+Joint-Secretariat forward text from `content.json → pipeline.qv_block`.
 
-```json
-{
-  "status": "final",          // was "pending"
-  "voters": <n>,
-  "credits_per_voter": <n>,
-  "principles": [ { "id": "P1", "votes": <n>, "credits": <n> }, ... ]
-}
-```
-
-then rebuild. While `status` is `"pending"` the section shows "Voting opens
-soon / in progress"; when `"final"` it renders a credits-per-principle bar
-chart. Principle ids must match `content.json` → `pipeline.principles`.
+A draft blog post accompanying these results lives at
+`documentation/geneva-reflections-blog-draft.md` (not built).
 
 ## TODO placeholders
 

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -349,6 +349,23 @@ description: "What would AI governance need to do so that everyone felt seen by 
         </li>
         {% endfor %}
       </ol>
+
+      {% if QV.status == "final" and QV.sorted %}
+      <h3 class="mt-8 mb-2">{{ C.pipeline.qv_block.title }}</h3>
+      <p class="gr-prose gr-counts mb-6">{{ C.pipeline.qv_block.explainer }}</p>
+      <div class="flex flex-col gap-2 mb-6" style="max-width: 46em">
+        {% for item in QV.sorted %}
+        <div class="gr-qv-row">
+          <span class="text-size--2">{{ item.title }}</span>
+          <span role="img" aria-label="{{ item.title }}: {{ item.votes }} votes{% if item.unanimous %}, every voter in favor{% elif item.against == 0 %}, none against{% endif %}"><span class="gr-qv-fill" style="width: {{ (item.votes / QV.maxVotes * 100) | round(1) }}%"></span></span>
+          <span class="gr-counts"><strong class="text-black">{{ item.votes }}</strong>{% if item.unanimous %} · every voter in favor{% endif %}</span>
+        </div>
+        {% endfor %}
+      </div>
+      <p class="gr-counts mb-6" style="max-width: 46em">{{ QV.voters }} voters · {{ QV.credits_per_voter }} credits each · aggregate totals only, by design.</p>
+      <p class="gr-prose mb-6">{{ C.pipeline.qv_block.insights }}</p>
+      <p class="gr-prose font-bold">{{ C.pipeline.qv_block.forward }}</p>
+      {% endif %}
     </div>
   </section>
 


### PR DESCRIPTION
Three things in one coherent update: the color feedback on #251, the final quadratic-vote results, and the page's forward story to the UN Joint Secretariat. Plus a draft companion blog post (not built).

## Intuitive vote colors
- **Agree → deep green `#166534`** (7.13:1 on white — text-grade, so the tally bolds keep the accent) · **Disagree → hatch in deep red `#A61B1B`** (7.52:1; the diagonal pattern still carries the encoding in grayscale/print/for colorblind readers) · Pass stays warm neutral.
- **Bloc C moves green → deep ochre `#8A5A0E`** (5.92:1) so the bloc system and the vote system never share a hue; bloc A stays blue. Removed the story draft's now-obsolete green-text contrast override (its bloc-C text follows the new ochre token).

## Quadratic-vote results — aggregate only
`qv-results.json` now carries the final outcome computed from the results sheet: **17 voters · 100 credits each · ten working-group ballot items.** ⚠️ The source sheet contains voter names; **only aggregate totals enter the repo and the page**, per the page's standing anonymity rules (verified: zero names in the built output).

Section 05 → **"What happened next"**: all four timeline steps complete, then **"What the vote prioritized"** — green bars sorted by net votes:

| Item | Votes | |
|---|---|---|
| Privacy, not surveillance | 62 | every voter in favor |
| Never manipulate | 62 | every voter in favor |
| Help us think, not answer for us | 50 | |
| Care that leads to people | 46 | |
| Answerable values | 45 | |
| Teach wise use | 44 | |
| Community-built AI | 44 | every voter in favor |
| Challenge and correct | 43 | |
| No engineered dependence | 41 | |
| The right to choose AI's place in faith | 15 | |

Insights paragraph ties the vote back to the page's story (red lines held under scarcity; the affirmative program confirmed under a budget; the room's open question left open on purpose), and the forward note records delivery of the ten Geneva Reflection Principles to the UN Joint Secretariat ten days after the event. The TL;DR gains one closing sentence carrying the outcome.

## Blog draft
`documentation/geneva-reflections-blog-draft.md` — a ~650-word companion post ("The room answered a question we didn't ask"), deliberately outside the build; publish by moving into `src/site/updates/` after review. Next-phase framing is kept generic and public-safe (no grant specifics).

Verified: zero broken anchors, zero duplicate cards, no voter names on either page, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)