### PR TITLE
Geneva Reflections: backward-looking cleanup

### DIFF
--- a/site-data/content.json
+++ b/site-data/content.json
@@ -103,13 +103,13 @@
   "groups": {
     "kicker": "02 · The people behind the votes",
     "title": "Two ways of seeing",
-    "intro": "Pol.is clusters participants by how they voted, not who they are. Two distinct ways of seeing the question emerged — and what separates them is the remedy, not whether AI needs remaking. These are positions, not caricatures — each is a coherent answer to what being “seen” by AI should mean.",
+    "intro": "Pol.is clusters participants by how they voted, not who they are. Two blocs emerged — split on the remedy, not on whether AI needs remaking.",
     "evidence_label": "Supporting evidence",
     "list": [
       {
         "key": "A",
         "name": "Boundary Keepers",
-        "sketch": "Wants clear limits on where AI belongs, and thinks some questions should only ever be answered by a person, and being deeply known by a machine reads as a loss, not a comfort. On community-built AI, they agreed or passed far more than they objected.",
+        "sketch": "Shares the concern about being known too well, and wants clear limits: some questions should only ever be answered by a person. On community-built AI they mostly passed rather than objected — openness to a vision they haven't yet seen demonstrated.",
         "cards": [],
         "references": [
           9,
@@ -121,8 +121,8 @@
       },
       {
         "key": "C",
-        "name": "Recognition Seekers",
-        "sketch": "Knows what it feels like when AI describes their faith or culture like an outsider. Their remedy is authorship: communities building and steering AI on their own terms — the one affirmative program in the data with broad support and no organized opposition.",
+        "name": "Communal Builders",
+        "sketch": "Knows what it feels like when AI describes their faith or culture like an outsider. Their answer is to build: communities authoring and governing AI on their own terms — the one affirmative program in the data.",
         "cards": [
           0,
           17,
@@ -136,43 +136,6 @@
       }
     ],
     "methods_note": "Per-bloc breakdowns cover the two blocs; the remaining participants are counted in totals only."
-  },
-  "split": {
-    "kicker": "03 · The deepest divide",
-    "title": "Where it genuinely split",
-    "lead": "“It isn't AI's job to reflect every culture's values” is the room's cleanest divide: the Boundary Keepers' signature position and the Recognition Seekers' sharpest rejection. Universality versus representation is a real disagreement, not a misunderstanding.",
-    "statement": 9
-  },
-  "surprise": {
-    "kicker": "04 · The findings a standard poll would miss",
-    "title": "The surprise",
-    "intro": "A standard opinion report stops at what separates the blocs. The two most consequential findings here run the other way — an agreement that joins the two blocs across their deepest divide, and a question that splits each bloc from within.",
-    "bedfellows": {
-      "finding_label": "Finding one — agreement across the divide",
-      "title": "Strange bedfellows",
-      "caption": "Boundary Keepers and Recognition Seekers stand at opposite poles on whose job it is to reflect a culture's values. But on one thing they speak with a single voice: they do not want AI to know them intimately. “I don't want to feel seen by AI” carried both blocs and the statements of loss beside it lean the same way.",
-      "reading": "How to read the cards: in each one, both blocs — the rivals of the divide above — lean the same way. Agreement that crosses the room's main fault line is the finding.",
-      "takeaway": "This is the room's hidden second consensus: whatever else AI becomes, the right not to be intimately known by it must be protected.",
-      "statements": [
-        23,
-        30,
-        55
-      ],
-      "cross_ref_note": "The divide these two blocs are known for:"
-    },
-    "inner_life": {
-      "finding_label": "Finding two — the divide inside each bloc",
-      "title": "The question that splits both blocs",
-      "caption": "Whether AI belongs in the inner and spiritual life — as a deepener of tradition, a moral interlocutor, or not at all — is not a fight between the blocs. It runs through them: members of the same bloc, who vote together on nearly everything else, part ways here.",
-      "reading": "How to read the cards: the bars below are within each bloc. Where a bloc's bar shows both solid (agree) and striped (disagree) in near-equal measure, that bloc is divided against itself.",
-      "takeaway": "Neither bloc can settle this question for the room, because neither has settled it for itself.",
-      "statements": [
-        1,
-        12,
-        33,
-        43
-      ]
-    }
   },
   "notes": {
     "title": "Reading these numbers",
@@ -195,27 +158,27 @@
     "csv_path": "/files/geneva-reflections-statements.csv"
   },
   "pipeline": {
-    "kicker": "05 · From results to principles",
-    "title": "What happened next",
+    "kicker": "04 · How it happened",
+    "title": "From a room to the UN",
     "steps": [
       {
         "label": "Pol.is deliberation",
-        "detail": "39 participants, live during the side event and open for 24 hours after — the results on this page.",
+        "detail": "39 participants wrote and voted on 84 statements, live and for 24 hours after — the results above.",
         "status": "done"
       },
       {
         "label": "Reflections Working Group",
-        "detail": "Participants distilled the record into ten Geneva Reflection Principles and set the ballot.",
+        "detail": "Participants distilled the record into ten Geneva Reflection Principles.",
         "status": "done"
       },
       {
         "label": "Quadratic vote",
-        "detail": "17 participants weighed the ten principles, each with a budget of 100 voice credits.",
+        "detail": "17 participants weighed the ten principles, 99 credits each.",
         "status": "done"
       },
       {
         "label": "UN Joint Secretariat",
-        "detail": "The principles, with their full voting record, were delivered to the Global Dialogue's Joint Secretariat ten days after the event.",
+        "detail": "The principles and their voting record, delivered ten days after the event.",
         "status": "done"
       }
     ],
@@ -338,8 +301,8 @@
     ],
     "qv_block": {
       "title": "What the vote prioritized",
-      "explainer": "Each of the 17 voters had 100 credits; one vote costs 1 credit, two cost 4, three cost 9 — so spending reveals how much people care, not just what they prefer. The ballot allowed spending against an item.",
-      "insights": "Three readings stand out. The room's red lines held under scarcity: forced to budget, Privacy, not surveillance and Never manipulate tied for first, and not one voter spent against either. The affirmative program held too: Community-built AI drew credits from every single voter — broad support and no organized opposition, confirmed under a budget. And the room spent on shared floors rather than on settling its inner divide: the right to choose AI's place in faith drew the least spending, with five voters leaving it untouched — the question the deliberation left open stayed open, on purpose.",
+      "explainer": "Each of the 17 voters had 99 credits: one vote costs 1, two cost 4, three cost 9 — spending reveals how much people care, and a budget just shy of 100 nudges it across items. Spending against an item was allowed.",
+      "insights": "The protections came first: Privacy, not surveillance and Never manipulate tied at 62, with not one vote against. Community-built AI finished mid-table on votes — but it was one of only three items every voter spent credits on: broad, unopposed support rather than intensity. And the room declined to force its open question: AI's place in faith drew the least spending.",
       "forward": "Ten days after the event, the ten Geneva Reflection Principles — with this voting record — were delivered to the UN Joint Secretariat of the Global Dialogue on AI Governance. The conveners are now shaping the next phase: supporting communities of belief to author and govern AI of their own."
     }
   },
@@ -370,6 +333,21 @@
   },
   "tldr": {
     "kicker": "00 · The TL;DR",
-    "text": "The room drew its red lines together — against intimate personalization, surveillance, and AI that flatters rather than challenges — and then split not over whether AI needs remaking but over the remedy. The larger bloc's answer is authorship: communities building and steering AI on their own terms. The smaller bloc's answer is boundaries: whoever builds it, some human ground stays reserved. And the boundary-keepers appear open to communal AI — they mainly passed or agreed with those statements, an invitation to demonstrate rather than a door closed. That makes authorship the one affirmative program in the data with broad support and no organized opposition. In the closing quadratic vote, protection from surveillance and manipulation tied for first — with not one vote against — and every voter spent credits for community-built AI. The ten principles are now with the UN Joint Secretariat."
+    "text": "The room agreed on the danger: AI that knows us too well — personalization sliding into dependence, dependence eroding human relationships. It split only on the remedy: Communal Builders are ready to author AI on their communities' own terms, while Boundary Keepers share the concern and mostly passed on the rest — an invitation to demonstrate. The closing vote confirmed the floor: the protections came first, and community-built AI was one of only three items every voter backed."
+  },
+  "concern": {
+    "kicker": "03 · The through-line",
+    "title": "The shared concern",
+    "intro": "Underneath everything, one worry unites the room: AI that comes too close to the person. Being known too deeply, engineered dependence, machines standing in for human relationships — both blocs drew the same line, and the closing vote put it first.",
+    "statements": [
+      23,
+      30
+    ],
+    "cross_refs": [
+      {
+        "id": 16,
+        "label": "The design demand this points to — statement [16], under Don't use knowing us against us"
+      }
+    ]
   }
 }

--- a/site-data/qv-results.json
+++ b/site-data/qv-results.json
@@ -2,8 +2,8 @@
   "status": "final",
   "voted_at": "2026-07-14",
   "voters": 17,
-  "credits_per_voter": 100,
-  "note": "Aggregates only, by design. One vote costs 1 credit, two cost 4, three cost 9; the ballot allowed spending against an item.",
+  "credits_per_voter": 99,
+  "note": "Aggregates only, by design. One vote costs 1 credit, two cost 4, three cost 9; a 99-credit budget nudges spending across items; the ballot allowed spending against an item.",
   "items": [
     {
       "title": "Challenge and correct",

--- a/src/site/_data/geneva.js
+++ b/src/site/_data/geneva.js
@@ -47,10 +47,12 @@ module.exports = () => {
     (t.supporting || []).forEach(claim);
   });
   content.groups.list.forEach((g) => (g.cards || []).forEach(claim));
-  claim(content.split.statement);
-  if (content.split.resolved) claim(content.split.resolved.statement);
-  content.surprise.bedfellows.statements.forEach(claim);
-  content.surprise.inner_life.statements.forEach(claim);
+  if (content.split) claim(content.split.statement);
+  if (content.surprise) {
+    content.surprise.bedfellows.statements.forEach(claim);
+    content.surprise.inner_life.statements.forEach(claim);
+  }
+  if (content.concern) content.concern.statements.forEach(claim);
   content.carded = carded;
 
   // Final quadratic-vote results: aggregate item totals only (never voter-

--- a/src/site/_includes/css/geneva-reflections.css
+++ b/src/site/_includes/css/geneva-reflections.css
@@ -74,7 +74,7 @@
 }
 @media (min-width: 640px) {
   .geneva .gr-stats {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 /* stats stacked in a column beside the video */

--- a/src/site/geneva-reflections/README.md
+++ b/src/site/geneva-reflections/README.md
@@ -29,8 +29,8 @@ src/site/js/geneva-reflections.js            <- progressive enhancement (video, 
 ```
 
 The main page is tiered: Tier 1 reads top-to-bottom with no interaction
-(consensus themes with one exemplar card each, the group portraits, the [9]
-divide, the bridging centerpiece, the pipeline); Tier 2 is native `<details>`
+(TL;DR, four pillars with one flagship card each, the bloc portraits, the
+shared-concern section, the process story with the QV results); Tier 2 is native `<details>`
 expanders (supporting statements, group signature cards, divide detail);
 Tier 3 is the full table on /geneva-reflections/data/ plus the CSV download.
 
@@ -68,8 +68,8 @@ final data changes a *story* (e.g. a within-group split disappearing).
 Analysis rules live at the top of `scripts/analyze.py`: non-substantive
 statements (22, 72, 75) excluded from rankings and the table; statements
 0–19 are facilitator seeds; the 15:05 clustering yields two blocs — group
-id 0 → bloc A (13, includes the facilitator seed account) and 2 → bloc C
-(22) — plus a 2-member leftover cluster and two unclustered participants,
+id 0 → bloc A (13, Boundary Keepers; includes the facilitator seed account)
+and 2 → bloc C (22, Communal Builders) — plus a 2-member leftover cluster and two unclustered participants,
 all counted in totals but never rendered as a faction; consensus =
 minimum agree rate across blocs A/C (≥4 votes per bloc); divisiveness =
 spread of net agreement between them; per-bloc tallies on fewer than 5

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -196,7 +196,6 @@ description: "What would AI governance need to do so that everyone felt seen by 
         <div class="gr-stat"><span class="gr-stat-number">{{ P.participants }}</span><span class="gr-stat-label">participants</span></div>
         <div class="gr-stat"><span class="gr-stat-number">{{ P.total_statements }}</span><span class="gr-stat-label">statements deliberated</span></div>
         <div class="gr-stat"><span class="gr-stat-number">{{ QV.items | length }}</span><span class="gr-stat-label">principles distilled</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ QV.voters }}</span><span class="gr-stat-label">quadratic-vote voters</span></div>
       </div>
     </div>
   </section>

--- a/src/site/geneva-reflections/index.njk
+++ b/src/site/geneva-reflections/index.njk
@@ -97,8 +97,8 @@ description: "What would AI governance need to do so that everyone felt seen by 
 </div>
 {% endmacro %}
 
-{% set blocNames = {"A": "Boundary Keepers", "C": "Recognition Seekers"} %}
-{% set blocShort = {"A": "Boundary", "C": "Recognition"} %}
+{% set blocNames = {"A": "Boundary Keepers", "C": "Communal Builders"} %}
+{% set blocShort = {"A": "Boundary", "C": "Communal"} %}
 
 {% macro groupRows(s) %}
 <div class="flex flex-col gap-1">
@@ -194,9 +194,9 @@ description: "What would AI governance need to do so that everyone felt seen by 
       <div class="gr-stats">
     {% endif %}
         <div class="gr-stat"><span class="gr-stat-number">{{ P.participants }}</span><span class="gr-stat-label">participants</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ C.stats.continents_display }}</span><span class="gr-stat-label">continents</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ P.total_statements }}</span><span class="gr-stat-label">statements</span></div>
-        <div class="gr-stat"><span class="gr-stat-number">{{ P.opinion_groups }}</span><span class="gr-stat-label">opinion groups found</span></div>
+        <div class="gr-stat"><span class="gr-stat-number">{{ P.total_statements }}</span><span class="gr-stat-label">statements deliberated</span></div>
+        <div class="gr-stat"><span class="gr-stat-number">{{ QV.items | length }}</span><span class="gr-stat-label">principles distilled</span></div>
+        <div class="gr-stat"><span class="gr-stat-number">{{ QV.voters }}</span><span class="gr-stat-label">quadratic-vote voters</span></div>
       </div>
     </div>
   </section>
@@ -291,49 +291,24 @@ description: "What would AI governance need to do so that everyone felt seen by 
     </div>
   </section>
 
-  {# ---------- 3. where it genuinely split ---------- #}
-  <section id="split" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-6 mb-6 lg:mb-0">
-      <p class="gr-kicker mb-2">{{ C.split.kicker }}</p>
-      <h2 class="mb-4">{{ C.split.title }}</h2>
-      <p class="gr-prose mb-4">{{ C.split.lead }}</p>
-    </div>
-    <div class="col-span-columns lg:col-start-column-7 lg:col-end-margin-2">
-      {{ cardFull(C.split.statement) }}
-    </div>
-  </section>
-
-  {# ---------- 4. the surprise (centerpiece) ---------- #}
-  <section id="surprise" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
+  {# ---------- 3. the shared concern ---------- #}
+  {% if C.concern %}
+  <section id="concern" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
     <div class="col-span-columns lg:col-start-column-1 lg:col-end-margin-2 gr-feature">
-      <p class="gr-kicker mb-2">{{ C.surprise.kicker }}</p>
-      <h2 class="mb-4">{{ C.surprise.title }}</h2>
-      <p class="gr-prose mb-10">{{ C.surprise.intro }}</p>
-
-      <p class="gr-kicker mb-1">{{ C.surprise.bedfellows.finding_label }}</p>
-      <h3 class="mb-2">{{ C.surprise.bedfellows.title }}</h3>
-      <p class="gr-prose mb-3">{{ C.surprise.bedfellows.caption }}</p>
-      <p class="gr-prose text-size--1 mb-2"><em>{{ C.surprise.bedfellows.reading }}</em></p>
-      <p class="gr-counts gr-prose mb-6">{{ C.surprise.bedfellows.cross_ref_note }} {% for sid in [9, 0] %}{{ refLine(sid) }}{% if not loop.last %} · {% endif %}{% endfor %}</p>
-      <div class="grid gap-4 md:grid-cols-3 mb-4">
-        {% for sid in C.surprise.bedfellows.statements %}
+      <p class="gr-kicker mb-2">{{ C.concern.kicker }}</p>
+      <h2 class="mb-4">{{ C.concern.title }}</h2>
+      <p class="gr-prose mb-6">{{ C.concern.intro }}</p>
+      <div class="grid gap-4 md:grid-cols-2 mb-4" style="max-width: 56em">
+        {% for sid in C.concern.statements %}
         {{ cardFull(sid) }}
         {% endfor %}
       </div>
-      <p class="gr-prose font-bold text-size--1 mb-12">{{ C.surprise.bedfellows.takeaway }}</p>
-
-      <p class="gr-kicker mb-1">{{ C.surprise.inner_life.finding_label }}</p>
-      <h3 class="mb-2">{{ C.surprise.inner_life.title }}</h3>
-      <p class="gr-prose mb-3">{{ C.surprise.inner_life.caption }}</p>
-      <p class="gr-prose text-size--1 mb-6"><em>{{ C.surprise.inner_life.reading }}</em></p>
-      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4 mb-4">
-        {% for sid in C.surprise.inner_life.statements %}
-        {{ cardFull(sid) }}
-        {% endfor %}
-      </div>
-      <p class="gr-prose font-bold text-size--1">{{ C.surprise.inner_life.takeaway }}</p>
+      {% if C.concern.cross_refs %}
+      <p class="gr-counts">{% for ref in C.concern.cross_refs %}<a class="underline" href="#s{{ ref.id }}">{{ ref.label }}</a>{% if not loop.last %} · {% endif %}{% endfor %}</p>
+      {% endif %}
     </div>
   </section>
+  {% endif %}
 
   {# ---------- 5. what happens next ---------- #}
   <section id="next" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
@@ -391,16 +366,7 @@ description: "What would AI governance need to do so that everyone felt seen by 
 
   {# ---------- page footer ---------- #}
   <section id="about-this-page" class="grid grid-cols-layout-4 lg:grid-cols-layout-12 pb-16">
-    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-7 mb-6 lg:mb-0">
-      <h3 class="mb-2">Take part in what comes next</h3>
-      <p class="gr-prose text-size--1 mb-3">The Reflections Working Group — open to event participants — refines the ballot before the quadratic vote.</p>
-      {% if C.footer.rwg_signup_url %}
-      <a class="underline font-bold" href="{{ C.footer.rwg_signup_url }}">{{ C.footer.rwg_signup_label }} →</a>
-      {% else %}
-      <p class="text-size--1"><strong>{{ C.footer.rwg_signup_label }}:</strong> sign-up link coming shortly — meanwhile, write to <a class="underline" href="mailto:{{ C.footer.contact_email }}">{{ C.footer.contact_email }}</a>.</p>
-      {% endif %}
-    </div>
-    <div class="col-span-columns lg:col-start-column-8 lg:col-end-margin-2">
+    <div class="col-span-columns lg:col-start-column-1 lg:col-end-gutter-9">
       <h3 class="mb-2">About this data</h3>
       <p class="gr-counts mb-2">{{ C.footer.data_note }}</p>
       <p class="gr-counts mb-2">{{ C.footer.polis_credit }} <a class="underline" href="{{ C.footer.polis_url }}">pol.is</a></p>


### PR DESCRIPTION
The page pivots from a Pol.is analysis report to a concise, backward-looking account of the whole process. **Net −631 words vs main.**

- **Stats bar** now spans the arc: 39 participants · 84 statements deliberated · 10 principles distilled · 17 quadratic-vote voters.
- **Credits corrected to 99** (not 100) everywhere — the odd budget nudges spending across items.
- **TL;DR** cut to four sentences, takeaway-first: the shared individualist concern (over-personalization → dependence → eroded relationships), the communal remedy, passes-as-invitation, and the vote confirming the floor.
- **"Where it genuinely split" removed** — concurring with the instinct: the [9] divide earned no QV resonance, and the bloc portraits already carry it. Its statements fall back to data-page links (verified, no dead anchors).
- **"The surprise" → "03 · The through-line: The shared concern"** — [23] and [30] cards under the individualist worry, cross-linked to [16]. The inner-life/spiritual exhibit is cut (least QV spending; mostly disagree/pass in the deliberation); the QV insights carry it in one line.
- **Recognition Seekers → Communal Builders** (page, data table, tooltips); sketches rewritten need-to-know: their openness to building, and Boundary Keepers' passes as openness to a vision not yet demonstrated.
- **QV honesty**: checked whether "every voter in favor" was distinctive — it was true of exactly **three** items (Privacy 62, Never manipulate 62, Community-built AI 44); all others had skippers or opponents. The page now says: *mid-table on votes, but one of only three items every voter spent credits on — broad, unopposed support rather than intensity.*
- **"Take part in what comes next" removed** (working group concluded); the process section is now "04 · How it happened / From a room to the UN" with the completed timeline, vote results, and the Joint-Secretariat delivery.

Verified on the built output: numbering runs 00→04 with no gaps, zero broken anchors, zero duplicate cards, no stale bloc names, "99 credits" throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)